### PR TITLE
Set panose custom parameter

### DIFF
--- a/0xProto-Regular.ufo/fontinfo.plist
+++ b/0xProto-Regular.ufo/fontinfo.plist
@@ -16,6 +16,19 @@
     <string>2023/06/01 01:15:37</string>
     <key>openTypeNameManufacturerURL</key>
     <string>https://0xtype.dev/</string>
+    <key>openTypeOS2Panose</key>
+    <array>
+      <integer>2</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+      <integer>9</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+      <integer>0</integer>
+    </array>
     <key>openTypeOS2Type</key>
     <array>
       <integer>3</integer>

--- a/0xProto.glyphs
+++ b/0xProto.glyphs
@@ -5,6 +5,21 @@ customParameters = (
 {
 name = isFixedPitch;
 value = 1;
+},
+{
+name = panose;
+value = (
+2,
+0,
+0,
+9,
+0,
+0,
+0,
+0,
+0,
+0
+);
 }
 );
 date = "2023-06-01 01:15:37 +0000";


### PR DESCRIPTION
closes https://github.com/0xType/0xProto/issues/10

## What 

Some Windows 10 applications did not recognize 0xProto as a monospace font. [panose](https://learn.microsoft.com/en-us/typography/opentype/spec/os2#panose) parameter was specified and the problem was solved.

