### PR TITLE
Use anchors

### DIFF
--- a/0xProto-Regular.ufo/features.fea
+++ b/0xProto-Regular.ufo/features.fea
@@ -1,3 +1,7 @@
+# automatic
+@Uppercase = [ A Aacute Acircumflex Adieresis Agrave Aring Atilde AE B C Ccedilla D Eth E Eacute Ecircumflex Edieresis Egrave F G H I Iacute Icircumflex Idieresis Igrave J K L M N Ntilde O Oacute Ocircumflex Odieresis Ograve Oslash Otilde OE P Q R S Scaron T U Uacute Ucircumflex Udieresis Ugrave V W X Y Yacute Ydieresis Z Zcaron
+];
+
 # Prefix: Languagesystems
 # automatic
 languagesystem DFLT dflt;
@@ -450,3 +454,26 @@ feature liga {
 ## sub less dollar greater by less_dollar_greater;
 ## sub percent percent by percent_percent;
 } liga;
+
+feature ccmp {
+# automatic
+lookup ccmp_Other_1 {
+	@CombiningTopAccents = [acutecomb caroncomb circumflexcomb dieresiscomb dotaccentcomb gravecomb ringcomb tildecomb];
+	lookupflag UseMarkFilteringSet @CombiningTopAccents;
+	sub i' @CombiningTopAccents by idotless;
+	sub j' @CombiningTopAccents by jdotless;
+} ccmp_Other_1;
+
+lookup ccmp_Other_2 {
+	@Markscomb = [dieresiscomb dotaccentcomb gravecomb acutecomb circumflexcomb caroncomb ringcomb tildecomb cedillacomb];
+	@MarkscombCase = [dieresiscomb.case dotaccentcomb.case gravecomb.case acutecomb.case circumflexcomb.case caroncomb.case ringcomb.case tildecomb.case cedillacomb.case];
+	sub @Markscomb @Markscomb' by @MarkscombCase;
+	sub @Uppercase @Markscomb' by @MarkscombCase;
+} ccmp_Other_2;
+
+lookup ccmp_Other_3 {
+	sub @Markscomb' @MarkscombCase by @MarkscombCase;
+	sub @MarkscombCase @Markscomb' by @MarkscombCase;
+} ccmp_Other_3;
+
+} ccmp;

--- a/0xProto-Regular.ufo/glyphs/A_.glif
+++ b/0xProto-Regular.ufo/glyphs/A_.glif
@@ -2,6 +2,9 @@
 <glyph name="A" format="2">
   <advance width="620"/>
   <unicode hex="0041"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="38" y="0" type="curve"/>
@@ -30,10 +33,4 @@
       <point x="464" y="258" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/28 07:57:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_E_.glif
+++ b/0xProto-Regular.ufo/glyphs/A_E_.glif
@@ -44,10 +44,4 @@
       <point x="594" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 06:23:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/A_acute.glif
@@ -2,14 +2,11 @@
 <glyph name="Aacute" format="2">
   <advance width="620"/>
   <unicode hex="00C1"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
   <outline>
     <component base="A"/>
-    <component base="acutecomb" xOffset="-1" yOffset="148"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:21:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_circumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/A_circumflex.glif
@@ -2,14 +2,11 @@
 <glyph name="Acircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00C2"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
   <outline>
     <component base="A"/>
-    <component base="circumflexcomb" yOffset="148"/>
+    <component base="circumflexcomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:28:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/A_dieresis.glif
@@ -2,39 +2,11 @@
 <glyph name="Adieresis" format="2">
   <advance width="620"/>
   <unicode hex="00C4"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="908" name="top"/>
   <outline>
-    <contour>
-      <point x="38" y="0" type="curve"/>
-      <point x="139" y="0" type="line"/>
-      <point x="207" y="304"/>
-      <point x="270" y="540"/>
-      <point x="352" y="710" type="curve"/>
-      <point x="258" y="710" type="line"/>
-      <point x="176" y="540"/>
-      <point x="106" y="304"/>
-    </contour>
-    <contour>
-      <point x="582" y="0" type="line"/>
-      <point x="514" y="304"/>
-      <point x="444" y="540"/>
-      <point x="362" y="710" type="curve"/>
-      <point x="268" y="710" type="line"/>
-      <point x="350" y="540"/>
-      <point x="413" y="304"/>
-      <point x="481" y="0" type="curve"/>
-    </contour>
-    <contour>
-      <point x="164" y="258" type="line"/>
-      <point x="164" y="170" type="line"/>
-      <point x="464" y="170" type="line"/>
-      <point x="464" y="258" type="line"/>
-    </contour>
-    <component base="dieresiscomb" xOffset="-1" yOffset="122"/>
+    <component base="A"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:30:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_grave.glif
+++ b/0xProto-Regular.ufo/glyphs/A_grave.glif
@@ -2,14 +2,11 @@
 <glyph name="Agrave" format="2">
   <advance width="620"/>
   <unicode hex="00C0"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
   <outline>
     <component base="A"/>
-    <component base="gravecomb" xOffset="-8" yOffset="148"/>
+    <component base="gravecomb.case" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:31:04</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_ring.glif
+++ b/0xProto-Regular.ufo/glyphs/A_ring.glif
@@ -2,14 +2,11 @@
 <glyph name="Aring" format="2">
   <advance width="620"/>
   <unicode hex="00C5"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="963" name="top"/>
   <outline>
     <component base="A"/>
-    <component base="ringcomb" yOffset="149"/>
+    <component base="ringcomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:32:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/A_tilde.glif
+++ b/0xProto-Regular.ufo/glyphs/A_tilde.glif
@@ -2,14 +2,11 @@
 <glyph name="Atilde" format="2">
   <advance width="620"/>
   <unicode hex="00C3"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="924" name="top"/>
   <outline>
     <component base="A"/>
-    <component base="tildecomb" xOffset="20" yOffset="142"/>
+    <component base="tildecomb.case" xOffset="10"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:32:34</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/B_.glif
+++ b/0xProto-Regular.ufo/glyphs/B_.glif
@@ -2,6 +2,9 @@
 <glyph name="B" format="2">
   <advance width="620"/>
   <unicode hex="0042"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="70" y="710" type="line"/>
@@ -66,10 +69,4 @@
       <point x="235" y="88"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 02:04:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/C_.glif
+++ b/0xProto-Regular.ufo/glyphs/C_.glif
@@ -2,6 +2,8 @@
 <glyph name="C" format="2">
   <advance width="620"/>
   <unicode hex="0043"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="341" y="-16" type="curve" smooth="yes"/>
@@ -32,10 +34,4 @@
       <point x="149" y="-16"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:17:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/C_cedilla.glif
+++ b/0xProto-Regular.ufo/glyphs/C_cedilla.glif
@@ -2,14 +2,10 @@
 <glyph name="Ccedilla" format="2">
   <advance width="620"/>
   <unicode hex="00C7"/>
+  <anchor x="310" y="-238" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <component base="C"/>
-    <component base="cedillacomb"/>
+    <component base="cedillacomb.case" xOffset="-15"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 07:00:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/D_.glif
+++ b/0xProto-Regular.ufo/glyphs/D_.glif
@@ -2,6 +2,9 @@
 <glyph name="D" format="2">
   <advance width="620"/>
   <unicode hex="0044"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="63" y="710" type="line"/>
@@ -38,10 +41,4 @@
       <point x="186" y="88"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/28 07:59:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_.glif
+++ b/0xProto-Regular.ufo/glyphs/E_.glif
@@ -2,6 +2,10 @@
 <glyph name="E" format="2">
   <advance width="620"/>
   <unicode hex="0045"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <contour>
       <point x="92" y="710" type="line"/>
@@ -28,10 +32,4 @@
       <point x="545" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/02 01:25:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/E_acute.glif
@@ -2,14 +2,12 @@
 <glyph name="Eacute" format="2">
   <advance width="620"/>
   <unicode hex="00C9"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="E"/>
-    <component base="acutecomb" yOffset="132"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:45:18</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_circumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/E_circumflex.glif
@@ -2,14 +2,12 @@
 <glyph name="Ecircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00CA"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="E"/>
-    <component base="circumflexcomb" xOffset="10" yOffset="148"/>
+    <component base="circumflexcomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:48:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/E_dieresis.glif
@@ -2,14 +2,12 @@
 <glyph name="Edieresis" format="2">
   <advance width="620"/>
   <unicode hex="00CB"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="908" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="E"/>
-    <component base="dieresiscomb" xOffset="11" yOffset="122"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 09:59:32</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_grave.glif
+++ b/0xProto-Regular.ufo/glyphs/E_grave.glif
@@ -2,14 +2,12 @@
 <glyph name="Egrave" format="2">
   <advance width="620"/>
   <unicode hex="00C8"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="E"/>
-    <component base="gravecomb" yOffset="148"/>
+    <component base="gravecomb.case" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:49:35</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/E_th.glif
+++ b/0xProto-Regular.ufo/glyphs/E_th.glif
@@ -44,10 +44,4 @@
       <point x="347" y="391" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 07:35:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/F_.glif
+++ b/0xProto-Regular.ufo/glyphs/F_.glif
@@ -2,6 +2,8 @@
 <glyph name="F" format="2">
   <advance width="620"/>
   <unicode hex="0046"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="92" y="710" type="line"/>
@@ -22,10 +24,4 @@
       <point x="544" y="622" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/02 01:26:18</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/G_.glif
+++ b/0xProto-Regular.ufo/glyphs/G_.glif
@@ -2,6 +2,8 @@
 <glyph name="G" format="2">
   <advance width="620"/>
   <unicode hex="0047"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="319" y="340" type="line"/>
@@ -40,10 +42,4 @@
       <point x="507" y="596" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:17:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/H_.glif
+++ b/0xProto-Regular.ufo/glyphs/H_.glif
@@ -2,6 +2,10 @@
 <glyph name="H" format="2">
   <advance width="620"/>
   <unicode hex="0048"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <contour>
       <point x="80" y="710" type="line"/>
@@ -22,10 +26,4 @@
       <point x="511" y="326" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:17:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/I_.glif
+++ b/0xProto-Regular.ufo/glyphs/I_.glif
@@ -2,6 +2,10 @@
 <glyph name="I" format="2">
   <advance width="620"/>
   <unicode hex="0049"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <contour>
       <point x="261" y="0" type="line"/>
@@ -22,10 +26,4 @@
       <point x="90" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/26 15:20:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/I_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/I_acute.glif
@@ -2,14 +2,12 @@
 <glyph name="Iacute" format="2">
   <advance width="620"/>
   <unicode hex="00CD"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="I"/>
-    <component base="acutecomb" xOffset="-17" yOffset="148"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:09:53</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/I_circumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/I_circumflex.glif
@@ -2,14 +2,12 @@
 <glyph name="Icircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00CE"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="I"/>
-    <component base="circumflexcomb" yOffset="148"/>
+    <component base="circumflexcomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:43:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/I_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/I_dieresis.glif
@@ -2,14 +2,12 @@
 <glyph name="Idieresis" format="2">
   <advance width="620"/>
   <unicode hex="00CF"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="908" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="I"/>
-    <component base="dieresiscomb" yOffset="122"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:09:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/I_grave.glif
+++ b/0xProto-Regular.ufo/glyphs/I_grave.glif
@@ -2,14 +2,12 @@
 <glyph name="Igrave" format="2">
   <advance width="620"/>
   <unicode hex="00CC"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="I"/>
-    <component base="gravecomb" xOffset="9" yOffset="148"/>
+    <component base="gravecomb.case" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:09:43</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/J_.glif
+++ b/0xProto-Regular.ufo/glyphs/J_.glif
@@ -2,6 +2,8 @@
 <glyph name="J" format="2">
   <advance width="620"/>
   <unicode hex="004A"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="528" y="208" type="curve"/>
@@ -32,10 +34,4 @@
       <point x="528" y="202" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/K_.glif
+++ b/0xProto-Regular.ufo/glyphs/K_.glif
@@ -2,6 +2,8 @@
 <glyph name="K" format="2">
   <advance width="620"/>
   <unicode hex="004B"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="466" y="0" type="line"/>
@@ -20,10 +22,4 @@
       <point x="222" y="312" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/L_.glif
+++ b/0xProto-Regular.ufo/glyphs/L_.glif
@@ -2,6 +2,10 @@
 <glyph name="L" format="2">
   <advance width="620"/>
   <unicode hex="004C"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <contour>
       <point x="101" y="710" type="line"/>
@@ -16,10 +20,4 @@
       <point x="539" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 07:34:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/M_.glif
+++ b/0xProto-Regular.ufo/glyphs/M_.glif
@@ -2,6 +2,8 @@
 <glyph name="M" format="2">
   <advance width="620"/>
   <unicode hex="004D"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="271" y="260" type="curve"/>
@@ -36,10 +38,4 @@
       <point x="269" y="260" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/N_.glif
+++ b/0xProto-Regular.ufo/glyphs/N_.glif
@@ -2,6 +2,8 @@
 <glyph name="N" format="2">
   <advance width="620"/>
   <unicode hex="004E"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="557" y="0" type="line"/>
@@ -22,10 +24,4 @@
       <point x="564" y="710" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/N_tilde.glif
+++ b/0xProto-Regular.ufo/glyphs/N_tilde.glif
@@ -2,14 +2,10 @@
 <glyph name="Ntilde" format="2">
   <advance width="620"/>
   <unicode hex="00D1"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="924" name="top"/>
   <outline>
     <component base="N"/>
-    <component base="tildecomb" xOffset="16" yOffset="142"/>
+    <component base="tildecomb.case" xOffset="10"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:28:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_.glif
+++ b/0xProto-Regular.ufo/glyphs/O_.glif
@@ -2,6 +2,12 @@
 <glyph name="O" format="2">
   <advance width="620"/>
   <unicode hex="004F"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <contour>
       <point x="310" y="-16" type="curve" smooth="yes"/>
@@ -32,10 +38,4 @@
       <point x="448" y="73"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:32</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_E_.glif
+++ b/0xProto-Regular.ufo/glyphs/O_E_.glif
@@ -2,6 +2,8 @@
 <glyph name="OE" format="2">
   <advance width="620"/>
   <unicode hex="0152"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="299" y="572" type="curve"/>
@@ -58,10 +60,4 @@
       <point x="564" y="308" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 06:23:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/O_acute.glif
@@ -2,14 +2,14 @@
 <glyph name="Oacute" format="2">
   <advance width="620"/>
   <unicode hex="00D3"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="O"/>
-    <component base="acutecomb" yOffset="147"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:26:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_circumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/O_circumflex.glif
@@ -2,14 +2,14 @@
 <glyph name="Ocircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00D4"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="O"/>
-    <component base="circumflexcomb" yOffset="147"/>
+    <component base="circumflexcomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:26:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/O_dieresis.glif
@@ -2,14 +2,14 @@
 <glyph name="Odieresis" format="2">
   <advance width="620"/>
   <unicode hex="00D6"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="908" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="O"/>
-    <component base="dieresiscomb" yOffset="123"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:26:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_grave.glif
+++ b/0xProto-Regular.ufo/glyphs/O_grave.glif
@@ -2,14 +2,14 @@
 <glyph name="Ograve" format="2">
   <advance width="620"/>
   <unicode hex="00D2"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="O"/>
-    <component base="gravecomb" yOffset="148"/>
+    <component base="gravecomb.case" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:27:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_slash.glif
+++ b/0xProto-Regular.ufo/glyphs/O_slash.glif
@@ -2,6 +2,12 @@
 <glyph name="Oslash" format="2">
   <advance width="620"/>
   <unicode hex="00D8"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <contour>
       <point x="22" y="-86" type="line"/>
@@ -13,10 +19,4 @@
     </contour>
     <component base="O"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:25:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/O_tilde.glif
+++ b/0xProto-Regular.ufo/glyphs/O_tilde.glif
@@ -2,14 +2,14 @@
 <glyph name="Otilde" format="2">
   <advance width="620"/>
   <unicode hex="00D5"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="924" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="O"/>
-    <component base="tildecomb" xOffset="1" yOffset="141"/>
+    <component base="tildecomb.case" xOffset="10"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:28:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/P_.glif
+++ b/0xProto-Regular.ufo/glyphs/P_.glif
@@ -2,6 +2,8 @@
 <glyph name="P" format="2">
   <advance width="620"/>
   <unicode hex="0050"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="62" y="710" type="line"/>
@@ -38,10 +40,4 @@
       <point x="227" y="350"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 07:35:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Q_.glif
+++ b/0xProto-Regular.ufo/glyphs/Q_.glif
@@ -2,6 +2,8 @@
 <glyph name="Q" format="2">
   <advance width="620"/>
   <unicode hex="0051"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="306" y="-16" type="curve" smooth="yes"/>
@@ -50,10 +52,4 @@
       <point x="415" y="94" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/28 05:44:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/R_.glif
+++ b/0xProto-Regular.ufo/glyphs/R_.glif
@@ -2,6 +2,8 @@
 <glyph name="R" format="2">
   <advance width="620"/>
   <unicode hex="0052"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="65" y="710" type="line"/>
@@ -45,10 +47,4 @@
       <point x="580" y="10" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:43</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/S_.glif
+++ b/0xProto-Regular.ufo/glyphs/S_.glif
@@ -2,6 +2,8 @@
 <glyph name="S" format="2">
   <advance width="620"/>
   <unicode hex="0053"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="50" y="92" type="line"/>
@@ -38,10 +40,4 @@
       <point x="113" y="160" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 07:35:43</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/S_caron.glif
+++ b/0xProto-Regular.ufo/glyphs/S_caron.glif
@@ -2,14 +2,10 @@
 <glyph name="Scaron" format="2">
   <advance width="620"/>
   <unicode hex="0160"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="934" name="top"/>
   <outline>
     <component base="S"/>
-    <component base="circumflexcomb" yScale="-1" yOffset="1542"/>
+    <component base="caroncomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 00:32:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/T_.glif
+++ b/0xProto-Regular.ufo/glyphs/T_.glif
@@ -2,6 +2,9 @@
 <glyph name="T" format="2">
   <advance width="620"/>
   <unicode hex="0054"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="355" name="center"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="261" y="0" type="line"/>
@@ -16,10 +19,4 @@
       <point x="50" y="622" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:48</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/U_.glif
+++ b/0xProto-Regular.ufo/glyphs/U_.glif
@@ -2,6 +2,10 @@
 <glyph name="U" format="2">
   <advance width="620"/>
   <unicode hex="0055"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <contour>
       <point x="465" y="710" type="line"/>
@@ -24,10 +28,4 @@
       <point x="565" y="710" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/27 02:48:30</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/U_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/U_acute.glif
@@ -2,14 +2,12 @@
 <glyph name="Uacute" format="2">
   <advance width="620"/>
   <unicode hex="00DA"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="U"/>
-    <component base="acutecomb" yOffset="148"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:51:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/U_circumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/U_circumflex.glif
@@ -2,14 +2,12 @@
 <glyph name="Ucircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00DB"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="U"/>
-    <component base="circumflexcomb" yOffset="148"/>
+    <component base="circumflexcomb.case" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:51:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/U_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/U_dieresis.glif
@@ -2,14 +2,12 @@
 <glyph name="Udieresis" format="2">
   <advance width="620"/>
   <unicode hex="00DC"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="908" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="U"/>
-    <component base="dieresiscomb" yOffset="122"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:51:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/U_grave.glif
+++ b/0xProto-Regular.ufo/glyphs/U_grave.glif
@@ -2,14 +2,12 @@
 <glyph name="Ugrave" format="2">
   <advance width="620"/>
   <unicode hex="00D9"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="600" y="710" name="topright"/>
   <outline>
     <component base="U"/>
-    <component base="gravecomb" yOffset="148"/>
+    <component base="gravecomb.case" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:52:09</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/V_.glif
+++ b/0xProto-Regular.ufo/glyphs/V_.glif
@@ -2,6 +2,8 @@
 <glyph name="V" format="2">
   <advance width="620"/>
   <unicode hex="0056"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="38" y="710" type="line"/>
@@ -24,10 +26,4 @@
       <point x="514" y="406"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/W_.glif
+++ b/0xProto-Regular.ufo/glyphs/W_.glif
@@ -2,6 +2,8 @@
 <glyph name="W" format="2">
   <advance width="620"/>
   <unicode hex="0057"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="30" y="710" type="line"/>
@@ -36,10 +38,4 @@
       <point x="591" y="396"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:18:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/X_.glif
+++ b/0xProto-Regular.ufo/glyphs/X_.glif
@@ -2,6 +2,8 @@
 <glyph name="X" format="2">
   <advance width="620"/>
   <unicode hex="0058"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
   <outline>
     <contour>
       <point x="565" y="710" type="line"/>
@@ -32,10 +34,4 @@
       <point x="52" y="10" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:19:04</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Y_.glif
+++ b/0xProto-Regular.ufo/glyphs/Y_.glif
@@ -2,6 +2,9 @@
 <glyph name="Y" format="2">
   <advance width="620"/>
   <unicode hex="0059"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="710" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <contour>
       <point x="39" y="710" type="line"/>
@@ -24,10 +27,4 @@
       <point x="359" y="290" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/28 04:11:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Y_acute.glif
+++ b/0xProto-Regular.ufo/glyphs/Y_acute.glif
@@ -2,14 +2,11 @@
 <glyph name="Yacute" format="2">
   <advance width="620"/>
   <unicode hex="00DD"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="934" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="Y"/>
-    <component base="acutecomb" yOffset="148"/>
+    <component base="acutecomb.case" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:53:29</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Y_dieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/Y_dieresis.glif
@@ -2,14 +2,11 @@
 <glyph name="Ydieresis" format="2">
   <advance width="620"/>
   <unicode hex="0178"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="908" name="top"/>
+  <anchor x="20" y="710" name="topleft"/>
   <outline>
     <component base="Y"/>
-    <component base="dieresiscomb" yOffset="122"/>
+    <component base="dieresiscomb.case"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:53:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Z_.glif
+++ b/0xProto-Regular.ufo/glyphs/Z_.glif
@@ -22,10 +22,4 @@
       <point x="423" y="622" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/27 02:49:46</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/Z_caron.glif
+++ b/0xProto-Regular.ufo/glyphs/Z_caron.glif
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="Zcaron" format="2">
+  <advance width="620"/>
+  <unicode hex="017D"/>
+  <outline>
+    <component base="Z"/>
+    <component base="caroncomb.case"/>
+  </outline>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/a.glif
+++ b/0xProto-Regular.ufo/glyphs/a.glif
@@ -2,6 +2,9 @@
 <glyph name="a" format="2">
   <advance width="620"/>
   <unicode hex="0061"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="550" name="top"/>
   <outline>
     <contour>
       <point x="508" y="131" type="curve" smooth="yes"/>
@@ -49,10 +52,4 @@
       <point x="158" y="106"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/27 11:12:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/aacute.glif
+++ b/0xProto-Regular.ufo/glyphs/aacute.glif
@@ -2,14 +2,11 @@
 <glyph name="aacute" format="2">
   <advance width="620"/>
   <unicode hex="00E1"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="786" name="top"/>
   <outline>
     <component base="a"/>
-    <component base="acutecomb"/>
+    <component base="acutecomb" xOffset="-41"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/27 11:18:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/acircumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/acircumflex.glif
@@ -2,14 +2,11 @@
 <glyph name="acircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00E2"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="786" name="top"/>
   <outline>
     <component base="a"/>
     <component base="circumflexcomb" xOffset="-9"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/29 06:59:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/acutecomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/acutecomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="acutecomb.case" format="2">
+  <anchor x="336" y="710" name="_top"/>
+  <anchor x="336" y="934" name="top"/>
+  <outline>
+    <component base="acutecomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/acutecomb.glif
+++ b/0xProto-Regular.ufo/glyphs/acutecomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="acutecomb" format="2">
   <unicode hex="0301"/>
+  <anchor x="336" y="550" name="_top"/>
+  <anchor x="336" y="786" name="top"/>
   <outline>
     <contour>
       <point x="340" y="786" type="line"/>
@@ -12,10 +14,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:40:35</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/adieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/adieresis.glif
@@ -2,14 +2,11 @@
 <glyph name="adieresis" format="2">
   <advance width="620"/>
   <unicode hex="00E4"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="760" name="top"/>
   <outline>
     <component base="a"/>
-    <component base="dieresiscomb"/>
+    <component base="dieresiscomb" xOffset="-15"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:29:33</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ae.glif
+++ b/0xProto-Regular.ufo/glyphs/ae.glif
@@ -75,10 +75,4 @@
       <point x="513" y="312" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/06 02:51:43</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/agrave.glif
+++ b/0xProto-Regular.ufo/glyphs/agrave.glif
@@ -2,14 +2,11 @@
 <glyph name="agrave" format="2">
   <advance width="620"/>
   <unicode hex="00E0"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="291" y="786" name="top"/>
   <outline>
     <component base="gravecomb"/>
     <component base="a"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/27 11:12:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ampersand.glif
+++ b/0xProto-Regular.ufo/glyphs/ampersand.glif
@@ -53,10 +53,4 @@
       <point x="583" y="404" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:24:09</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ampersand.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/ampersand.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ampersand_ampersand.glif
+++ b/0xProto-Regular.ufo/glyphs/ampersand_ampersand.glif
@@ -101,10 +101,4 @@
       <point x="512" y="404" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:56:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/aring.glif
+++ b/0xProto-Regular.ufo/glyphs/aring.glif
@@ -2,14 +2,11 @@
 <glyph name="aring" format="2">
   <advance width="620"/>
   <unicode hex="00E5"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="815" name="top"/>
   <outline>
     <component base="a"/>
-    <component base="ringcomb" xOffset="-1"/>
+    <component base="ringcomb" xOffset="-15"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/31 07:31:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asciicircum.glif
+++ b/0xProto-Regular.ufo/glyphs/asciicircum.glif
@@ -18,10 +18,4 @@
       <point x="424" y="420" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/02 07:11:35</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asciitilde.glif
+++ b/0xProto-Regular.ufo/glyphs/asciitilde.glif
@@ -20,10 +20,4 @@
       <point x="204" y="360"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/16 06:39:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asterisk.glif
+++ b/0xProto-Regular.ufo/glyphs/asterisk.glif
@@ -34,10 +34,4 @@
       <point x="413" y="58" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/07/18 08:15:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asterisk.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/asterisk.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:07:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asterisk_asterisk.glif
+++ b/0xProto-Regular.ufo/glyphs/asterisk_asterisk.glif
@@ -63,10 +63,4 @@
       <point x="374" y="58" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:13:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asterisk_asterisk_asterisk.glif
+++ b/0xProto-Regular.ufo/glyphs/asterisk_asterisk_asterisk.glif
@@ -93,10 +93,4 @@
       <point x="301" y="58" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 00:08:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/asterisk_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/asterisk_greater.glif
@@ -47,10 +47,4 @@
       <point x="-148" y="58" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:44:19</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/at.glif
+++ b/0xProto-Regular.ufo/glyphs/at.glif
@@ -68,10 +68,4 @@
       <point x="364" y="86"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:24:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/atilde.glif
+++ b/0xProto-Regular.ufo/glyphs/atilde.glif
@@ -2,14 +2,11 @@
 <glyph name="atilde" format="2">
   <advance width="620"/>
   <unicode hex="00E3"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="295" y="776" name="top"/>
   <outline>
     <component base="a"/>
-    <component base="tildecomb" xOffset="6" yOffset="1"/>
+    <component base="tildecomb" xOffset="-5"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/06 02:46:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/b.glif
+++ b/0xProto-Regular.ufo/glyphs/b.glif
@@ -2,6 +2,9 @@
 <glyph name="b" format="2">
   <advance width="620"/>
   <unicode hex="0062"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="207" y="-8" type="line"/>
@@ -44,10 +47,4 @@
       <point x="207" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:19:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/backslash.glif
+++ b/0xProto-Regular.ufo/glyphs/backslash.glif
@@ -12,10 +12,4 @@
       <point x="503" y="-110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 07:40:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar.glif
+++ b/0xProto-Regular.ufo/glyphs/bar.glif
@@ -10,10 +10,4 @@
       <point x="359" y="-160" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/01 11:35:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/bar.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar_bar.glif
+++ b/0xProto-Regular.ufo/glyphs/bar_bar.glif
@@ -15,10 +15,4 @@
       <point x="260" y="-160" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:56:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar_bar_bar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/bar_bar_bar_greater.glif
@@ -35,10 +35,4 @@
       <point x="-782" y="-24" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:57:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar_bar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/bar_bar_greater.glif
@@ -29,10 +29,4 @@
       <point x="-694" y="-24" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:57:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar_bracketright.glif
+++ b/0xProto-Regular.ufo/glyphs/bar_bracketright.glif
@@ -27,10 +27,4 @@
       <point x="-212" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:56:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/bar_greater.glif
@@ -23,10 +23,4 @@
       <point x="-134" y="76" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:57:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndH_orizontal.glif
@@ -34,10 +34,4 @@
       <point x="630" y="246" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:17:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndL_eft.glif
@@ -28,10 +28,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:48:32</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleD_ownA_ndR_ight.glif
@@ -28,10 +28,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:49:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="630" y="246" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:43:48</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndH_orizontal.glif
@@ -34,10 +34,4 @@
       <point x="344" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:17:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndL_eft.glif
@@ -28,10 +28,4 @@
       <point x="-10" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:50:33</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleU_pA_ndR_ight.glif
@@ -28,10 +28,4 @@
       <point x="344" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:50:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleV_ertical.glif
@@ -16,10 +16,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:45:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndH_orizontal.glif
@@ -52,10 +52,4 @@
       <point x="630" y="246" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:17:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndL_eft.glif
@@ -34,10 +34,4 @@
       <point x="208" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:14:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_oubleV_erticalA_ndR_ight.glif
@@ -34,10 +34,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:15:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndH_orizontalS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndH_orizontalS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:15:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndL_eftS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndL_eftS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:52:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndR_ightS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownD_oubleA_ndR_ightS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:52:35</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndH_orizontalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndH_orizontalL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:50:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndL_eftL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndL_eftL_ight.glif
@@ -16,10 +16,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:42:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndL_eftU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndL_eftU_pL_ight.glif
@@ -28,10 +28,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:45:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndR_ightL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndR_ightL_ight.glif
@@ -16,10 +16,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:39:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndR_ightU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndR_ightU_pL_ight.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:42:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndU_pH_orizontalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownH_eavyA_ndU_pH_orizontalL_ight.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:57:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndH_orizontalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndH_orizontalH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:45:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndL_eftH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndL_eftH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="344" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:42:53</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndL_eftU_pH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndL_eftU_pH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:46:07</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndR_ightH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndR_ightH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:39:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndR_ightU_pH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndR_ightU_pH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:46:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndU_pH_orizontalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownL_ightA_ndU_pH_orizontalH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:29:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndH_orizontalD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndH_orizontalD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:17:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndL_eftD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndL_eftD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 01:58:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndR_ightD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxD_ownS_ingleA_ndR_ightD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 01:59:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_oubleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_oubleD_ashH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="230" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:36:56</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_oubleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_oubleD_ashV_ertical.glif
@@ -16,10 +16,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 06:15:29</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_own.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_own.glif
@@ -10,10 +10,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:30:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndL_eft.glif
@@ -16,10 +16,4 @@
       <point x="395" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:43:18</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyD_ownA_ndR_ight.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:39:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyH_orizontal.glif
@@ -10,10 +10,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:39:32</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyL_eft.glif
@@ -10,10 +10,4 @@
       <point x="276" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:31:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyL_eftA_ndL_ightR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyL_eftA_ndL_ightR_ight.glif
@@ -16,10 +16,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:32:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyQ_uadrupleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyQ_uadrupleD_ashH_orizontal.glif
@@ -28,10 +28,4 @@
       <point x="55" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 06:14:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyQ_uadrupleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyQ_uadrupleD_ashV_ertical.glif
@@ -28,10 +28,4 @@
       <point x="226" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:39:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyR_ight.glif
@@ -10,10 +10,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:32:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyT_ripleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyT_ripleD_ashH_orizontal.glif
@@ -22,10 +22,4 @@
       <point x="420" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:35:07</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyT_ripleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyT_ripleD_ashV_ertical.glif
@@ -22,10 +22,4 @@
       <point x="226" y="80" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:40:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyU_p.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyU_p.glif
@@ -10,10 +10,4 @@
       <point x="225" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:51:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndL_eft.glif
@@ -16,10 +16,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:43:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndL_ightD_own.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndL_ightD_own.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:51:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyU_pA_ndR_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:43:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyV_ertical.glif
@@ -10,10 +10,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:30:08</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndH_orizontal.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:30:09</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndL_eft.glif
@@ -16,10 +16,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:46:26</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxH_eavyV_erticalA_ndR_ight.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:46:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftD_ownH_eavyA_ndR_ightU_pL_ight.001.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftD_ownH_eavyA_ndR_ightU_pL_ight.001.glif
@@ -28,10 +28,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:32:09</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftD_ownH_eavyA_ndR_ightU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftD_ownH_eavyA_ndR_ightU_pL_ight.glif
@@ -16,10 +16,4 @@
       <point x="276" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightD_ownL_ight.glif
@@ -22,10 +22,4 @@
       <point x="345" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:46:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightU_pL_ight.glif
@@ -22,10 +22,4 @@
       <point x="344" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightV_erticalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftH_eavyA_ndR_ightV_erticalL_ight.glif
@@ -22,10 +22,4 @@
       <point x="344" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightD_ownH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightD_ownH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightU_pH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightU_pH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:51:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightV_erticalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftL_ightA_ndR_ightV_erticalH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:30:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_eftU_pH_eavyA_ndR_ightD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_eftU_pH_eavyA_ndR_ightD_ownL_ight.glif
@@ -28,10 +28,4 @@
       <point x="395" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:30:33</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightA_rcD_ownA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightA_rcD_ownA_ndL_eft.glif
@@ -18,10 +18,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:15:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightA_rcD_ownA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightA_rcD_ownA_ndR_ight.glif
@@ -18,10 +18,4 @@
       <point x="276" y="57" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:16:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightA_rcU_pA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightA_rcU_pA_ndL_eft.glif
@@ -18,10 +18,4 @@
       <point x="344" y="639" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:17:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightA_rcU_pA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightA_rcU_pA_ndR_ight.glif
@@ -18,10 +18,4 @@
       <point x="344" y="1130" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:28:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalC_ross.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalC_ross.glif
@@ -16,10 +16,4 @@
       <point x="-48" y="658" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 05:37:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalU_pperL_eftT_oL_owerR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalU_pperL_eftT_oL_owerR_ight.glif
@@ -10,10 +10,4 @@
       <point x="668" y="38" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 05:37:19</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalU_pperR_ightT_oL_owerL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_iagonalU_pperR_ightT_oL_owerL_eft.glif
@@ -10,10 +10,4 @@
       <point x="620" y="706" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 05:37:29</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_oubleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_oubleD_ashH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="230" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:34:44</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_oubleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_oubleD_ashV_ertical.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:40:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_own.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_own.glif
@@ -10,10 +10,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:58:19</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:07</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndL_eft.glif
@@ -16,10 +16,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:43:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightD_ownA_ndR_ight.glif
@@ -16,10 +16,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:40:35</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightH_orizontal.glif
@@ -10,10 +10,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:40:32</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightL_eft.glif
@@ -10,10 +10,4 @@
       <point x="276" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:57:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightL_eftA_ndH_eavyR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightL_eftA_ndH_eavyR_ight.glif
@@ -16,10 +16,4 @@
       <point x="412" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:57:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightQ_uadrupleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightQ_uadrupleD_ashH_orizontal.glif
@@ -28,10 +28,4 @@
       <point x="55" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:35:34</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightQ_uadrupleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightQ_uadrupleD_ashV_ertical.glif
@@ -28,10 +28,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:40:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightR_ight.glif
@@ -10,10 +10,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:57:46</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightT_ripleD_ashH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightT_ripleD_ashH_orizontal.glif
@@ -22,10 +22,4 @@
       <point x="420" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:35:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightT_ripleD_ashV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightT_ripleD_ashV_ertical.glif
@@ -22,10 +22,4 @@
       <point x="276" y="80" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:41:19</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightU_p.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightU_p.glif
@@ -10,10 +10,4 @@
       <point x="276" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:54:25</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndH_eavyD_own.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndH_eavyD_own.glif
@@ -16,10 +16,4 @@
       <point x="344" y="272" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:53:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndL_eft.glif
@@ -22,10 +22,4 @@
       <point x="276" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightU_pA_ndR_ight.glif
@@ -22,10 +22,4 @@
       <point x="276" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:22</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightV_ertical.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightV_ertical.glif
@@ -10,10 +10,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:33:00</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndH_orizontal.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndH_orizontal.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:08</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndL_eft.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndL_eft.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndR_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxL_ightV_erticalA_ndR_ight.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightD_ownH_eavyA_ndL_eftU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightD_ownH_eavyA_ndL_eftU_pL_ight.glif
@@ -28,10 +28,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:30:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftD_ownL_ight.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftU_pL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftU_pL_ight.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftV_erticalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightH_eavyA_ndL_eftV_erticalL_ight.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:26</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftD_ownH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftD_ownH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="395" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:34</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftU_pH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftU_pH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="395" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:43</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftV_erticalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightL_ightA_ndL_eftV_erticalH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:31:07</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxR_ightU_pH_eavyA_ndL_eftD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxR_ightU_pH_eavyA_ndL_eftD_ownL_ight.glif
@@ -28,10 +28,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:31:18</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndH_orizontalS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndH_orizontalS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:18:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndL_eftS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndL_eftS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:00:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndR_ightS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pD_oubleA_ndR_ightS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:00:39</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndD_ownH_orizontalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndD_ownH_orizontalL_ight.glif
@@ -22,10 +22,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:31:30</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndH_orizontalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndH_orizontalL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:52:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndL_eftD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndL_eftD_ownL_ight.glif
@@ -28,10 +28,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndL_eftL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndL_eftL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:39</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndR_ightD_ownL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndR_ightD_ownL_ight.glif
@@ -22,10 +22,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:48</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndR_ightL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pH_eavyA_ndR_ightL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:44:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndD_ownH_orizontalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndD_ownH_orizontalH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:31:44</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndH_orizontalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndH_orizontalH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:53:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndL_eftD_ownH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndL_eftD_ownH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndL_eftH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndL_eftH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="344" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:45:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndR_ightD_ownH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndR_ightD_ownH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:48</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndR_ightH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pL_ightA_ndR_ightH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:45:08</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndH_orizontalD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndH_orizontalD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="382" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:19:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndL_eftD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndL_eftD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="344" y="246" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:01:29</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndR_ightD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxU_pS_ingleA_ndR_ightD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="630" y="246" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:01:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndH_orizontalS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndH_orizontalS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="630" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:19:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndL_eftS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndL_eftS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="276" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:19:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndR_ightS_ingle.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalD_oubleA_ndR_ightS_ingle.glif
@@ -22,10 +22,4 @@
       <point x="631" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:03:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndH_orizontalL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndH_orizontalL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 05:31:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndL_eftL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndL_eftL_ight.glif
@@ -16,10 +16,4 @@
       <point x="344" y="314" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:47:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndR_ightL_ight.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalH_eavyA_ndR_ightL_ight.glif
@@ -16,10 +16,4 @@
       <point x="225" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:48:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndH_orizontalH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndH_orizontalH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="630" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:53:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndL_eftH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndL_eftH_eavy.glif
@@ -22,10 +22,4 @@
       <point x="344" y="263" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:48:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndR_ightH_eavy.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalL_ightA_ndR_ightH_eavy.glif
@@ -16,10 +16,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/12 04:45:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndH_orizontalD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndH_orizontalD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:20:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndL_eftD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndL_eftD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 03:20:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndR_ightD_ouble.glif
+++ b/0xProto-Regular.ufo/glyphs/boxV_erticalS_ingleA_ndR_ightD_ouble.glif
@@ -22,10 +22,4 @@
       <point x="276" y="-430" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/13 02:04:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/braceleft.glif
+++ b/0xProto-Regular.ufo/glyphs/braceleft.glif
@@ -59,10 +59,4 @@
       <point x="140" y="357" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:54:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/braceright.glif
+++ b/0xProto-Regular.ufo/glyphs/braceright.glif
@@ -59,10 +59,4 @@
       <point x="540" y="273" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:54:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bracketleft.glif
+++ b/0xProto-Regular.ufo/glyphs/bracketleft.glif
@@ -22,10 +22,4 @@
       <point x="470" y="-120" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:54:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bracketleft.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/bracketleft.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bracketleft_bar.glif
+++ b/0xProto-Regular.ufo/glyphs/bracketleft_bar.glif
@@ -27,10 +27,4 @@
       <point x="270" y="-120" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:41:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/bracketright.glif
+++ b/0xProto-Regular.ufo/glyphs/bracketright.glif
@@ -22,10 +22,4 @@
       <point x="405" y="-35" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:54:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/c.glif
+++ b/0xProto-Regular.ufo/glyphs/c.glif
@@ -2,6 +2,8 @@
 <glyph name="c" format="2">
   <advance width="620"/>
   <unicode hex="0063"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="337" y="-16" type="curve" smooth="yes"/>
@@ -32,10 +34,4 @@
       <point x="167" y="-18"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:19:53</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/caroncomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/caroncomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="caroncomb.case" format="2">
+  <anchor x="304" y="710" name="_top"/>
+  <anchor x="304" y="934" name="top"/>
+  <outline>
+    <component base="caroncomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/caroncomb.glif
+++ b/0xProto-Regular.ufo/glyphs/caroncomb.glif
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="caroncomb" format="2">
+  <unicode hex="030C"/>
+  <anchor x="304" y="550" name="_top"/>
+  <anchor x="304" y="786" name="top"/>
+  <outline>
+    <contour>
+      <point x="257" y="628" type="line"/>
+      <point x="351" y="628" type="line"/>
+      <point x="351" y="634" type="line"/>
+      <point x="220" y="786" type="line"/>
+      <point x="135" y="786" type="line"/>
+    </contour>
+    <contour>
+      <point x="351" y="628" type="line"/>
+      <point x="473" y="786" type="line"/>
+      <point x="388" y="786" type="line"/>
+      <point x="257" y="634" type="line"/>
+      <point x="257" y="628" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/ccedilla.glif
+++ b/0xProto-Regular.ufo/glyphs/ccedilla.glif
@@ -2,14 +2,10 @@
 <glyph name="ccedilla" format="2">
   <advance width="620"/>
   <unicode hex="00E7"/>
+  <anchor x="310" y="-238" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <component base="c"/>
-    <component base="cedillacomb" xOffset="-11"/>
+    <component base="cedillacomb" xOffset="-15"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 06:59:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/cedillacomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/cedillacomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="cedillacomb.case" format="2">
+  <anchor x="325" y="0" name="_bottom"/>
+  <anchor x="325" y="-238" name="bottom"/>
+  <outline>
+    <component base="cedillacomb"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/cedillacomb.glif
+++ b/0xProto-Regular.ufo/glyphs/cedillacomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="cedillacomb" format="2">
   <unicode hex="0327"/>
+  <anchor x="325" y="0" name="_bottom"/>
+  <anchor x="325" y="-238" name="bottom"/>
   <outline>
     <contour>
       <point x="282" y="-101" type="line"/>
@@ -30,10 +32,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 11:07:16</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/circumflexcomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/circumflexcomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="circumflexcomb.case" format="2">
+  <anchor x="304" y="710" name="_top"/>
+  <anchor x="304" y="934" name="top"/>
+  <outline>
+    <component base="circumflexcomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/circumflexcomb.glif
+++ b/0xProto-Regular.ufo/glyphs/circumflexcomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="circumflexcomb" format="2">
   <unicode hex="0302"/>
+  <anchor x="304" y="550" name="_top"/>
+  <anchor x="304" y="786" name="top"/>
   <outline>
     <contour>
       <point x="351" y="786" type="line"/>
@@ -19,10 +21,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:40:38</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/colon.glif
+++ b/0xProto-Regular.ufo/glyphs/colon.glif
@@ -32,10 +32,4 @@
       <point x="269" y="397"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/14 05:55:00</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/colon.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon_colon.glif
+++ b/0xProto-Regular.ufo/glyphs/colon_colon.glif
@@ -59,10 +59,4 @@
       <point x="157" y="397"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:42:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon_colon_colon.glif
+++ b/0xProto-Regular.ufo/glyphs/colon_colon_colon.glif
@@ -87,10 +87,4 @@
       <point x="89" y="397"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:42:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/colon_equal.glif
@@ -43,10 +43,4 @@
       <point x="440" y="359" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:42:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon_greater_colon.glif
+++ b/0xProto-Regular.ufo/glyphs/colon_greater_colon.glif
@@ -73,10 +73,4 @@
       <point x="-887" y="427"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:43:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/colon_less_colon.glif
+++ b/0xProto-Regular.ufo/glyphs/colon_less_colon.glif
@@ -73,10 +73,4 @@
       <point x="185" y="427"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:43:21</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/comma.glif
+++ b/0xProto-Regular.ufo/glyphs/comma.glif
@@ -24,10 +24,4 @@
       <point x="264" y="0"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:56:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/contents.plist
+++ b/0xProto-Regular.ufo/glyphs/contents.plist
@@ -118,6 +118,8 @@
     <string>Y_dieresis.glif</string>
     <key>Z</key>
     <string>Z_.glif</string>
+    <key>Zcaron</key>
+    <string>Z_caron.glif</string>
     <key>a</key>
     <string>a.glif</string>
     <key>aacute</key>
@@ -126,6 +128,8 @@
     <string>acircumflex.glif</string>
     <key>acutecomb</key>
     <string>acutecomb.glif</string>
+    <key>acutecomb.case</key>
+    <string>acutecomb.case.glif</string>
     <key>adieresis</key>
     <string>adieresis.glif</string>
     <key>ae</key>
@@ -446,12 +450,20 @@
     <string>bracketright.glif</string>
     <key>c</key>
     <string>c.glif</string>
+    <key>caroncomb</key>
+    <string>caroncomb.glif</string>
+    <key>caroncomb.case</key>
+    <string>caroncomb.case.glif</string>
     <key>ccedilla</key>
     <string>ccedilla.glif</string>
     <key>cedillacomb</key>
     <string>cedillacomb.glif</string>
+    <key>cedillacomb.case</key>
+    <string>cedillacomb.case.glif</string>
     <key>circumflexcomb</key>
     <string>circumflexcomb.glif</string>
+    <key>circumflexcomb.case</key>
+    <string>circumflexcomb.case.glif</string>
     <key>colon</key>
     <string>colon.glif</string>
     <key>colon.spacer</key>
@@ -472,12 +484,18 @@
     <string>d.glif</string>
     <key>dieresiscomb</key>
     <string>dieresiscomb.glif</string>
+    <key>dieresiscomb.case</key>
+    <string>dieresiscomb.case.glif</string>
     <key>dollar</key>
     <string>dollar.glif</string>
     <key>dollar.spacer</key>
     <string>dollar.spacer.glif</string>
     <key>dollar_greater</key>
     <string>dollar_greater.glif</string>
+    <key>dotaccentcomb</key>
+    <string>dotaccentcomb.glif</string>
+    <key>dotaccentcomb.case</key>
+    <string>dotaccentcomb.case.glif</string>
     <key>e</key>
     <string>e.glif</string>
     <key>eacute</key>
@@ -538,6 +556,8 @@
     <string>grave.glif</string>
     <key>gravecomb</key>
     <string>gravecomb.glif</string>
+    <key>gravecomb.case</key>
+    <string>gravecomb.case.glif</string>
     <key>greater</key>
     <string>greater.glif</string>
     <key>greater.spacer</key>
@@ -570,6 +590,8 @@
     <string>igrave.glif</string>
     <key>j</key>
     <string>j.glif</string>
+    <key>jdotless</key>
+    <string>jdotless.glif</string>
     <key>k</key>
     <string>k.glif</string>
     <key>l</key>
@@ -694,6 +716,8 @@
     <string>r.glif</string>
     <key>ringcomb</key>
     <string>ringcomb.glif</string>
+    <key>ringcomb.case</key>
+    <string>ringcomb.case.glif</string>
     <key>s</key>
     <string>s.glif</string>
     <key>scaron</key>
@@ -720,6 +744,8 @@
     <string>three.glif</string>
     <key>tildecomb</key>
     <string>tildecomb.glif</string>
+    <key>tildecomb.case</key>
+    <string>tildecomb.case.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>u</key>

--- a/0xProto-Regular.ufo/glyphs/d.glif
+++ b/0xProto-Regular.ufo/glyphs/d.glif
@@ -2,6 +2,10 @@
 <glyph name="d" format="2">
   <advance width="620"/>
   <unicode hex="0064"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="550" name="top"/>
+  <anchor x="600" y="750" name="topright"/>
   <outline>
     <contour>
       <point x="504" y="46" type="line"/>
@@ -48,10 +52,4 @@
       <point x="504" y="95"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:19:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/dieresiscomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/dieresiscomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dieresiscomb.case" format="2">
+  <anchor x="310" y="710" name="_top"/>
+  <anchor x="310" y="908" name="top"/>
+  <outline>
+    <component base="dieresiscomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/dieresiscomb.glif
+++ b/0xProto-Regular.ufo/glyphs/dieresiscomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="dieresiscomb" format="2">
   <unicode hex="0308"/>
+  <anchor x="310" y="550" name="_top"/>
+  <anchor x="310" y="760" name="top"/>
   <outline>
     <contour>
       <point x="158" y="760" type="line"/>
@@ -17,10 +19,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:46:11</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/dollar.glif
+++ b/0xProto-Regular.ufo/glyphs/dollar.glif
@@ -54,10 +54,4 @@
       <point x="435" y="352"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:24:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/dollar.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/dollar.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/10/29 06:55:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/dollar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/dollar_greater.glif
@@ -67,10 +67,4 @@
       <point x="-14" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:58:01</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/dotaccentcomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/dotaccentcomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dotaccentcomb.case" format="2">
+  <anchor x="305" y="710" name="_top"/>
+  <anchor x="305" y="914" name="top"/>
+  <outline>
+    <component base="dotaccentcomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/dotaccentcomb.glif
+++ b/0xProto-Regular.ufo/glyphs/dotaccentcomb.glif
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="dotaccentcomb" format="2">
+  <unicode hex="0307"/>
+  <anchor x="305" y="550" name="_top"/>
+  <anchor x="305" y="766" name="top"/>
+  <outline>
+    <contour>
+      <point x="305" y="606" type="curve" smooth="yes"/>
+      <point x="350" y="606"/>
+      <point x="385" y="641"/>
+      <point x="385" y="686" type="curve" smooth="yes"/>
+      <point x="385" y="730"/>
+      <point x="350" y="766"/>
+      <point x="305" y="766" type="curve" smooth="yes"/>
+      <point x="262" y="766"/>
+      <point x="225" y="730"/>
+      <point x="225" y="686" type="curve" smooth="yes"/>
+      <point x="225" y="641"/>
+      <point x="262" y="606"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/e.glif
+++ b/0xProto-Regular.ufo/glyphs/e.glif
@@ -2,6 +2,9 @@
 <glyph name="e" format="2">
   <advance width="620"/>
   <unicode hex="0065"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="328" y="-16" type="curve" smooth="yes"/>
@@ -35,10 +38,4 @@
       <point x="462" y="303" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:01</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/eacute.glif
+++ b/0xProto-Regular.ufo/glyphs/eacute.glif
@@ -2,14 +2,11 @@
 <glyph name="eacute" format="2">
   <advance width="620"/>
   <unicode hex="00E9"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
   <outline>
     <component base="e"/>
-    <component base="acutecomb"/>
+    <component base="acutecomb" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:37:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ecircumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/ecircumflex.glif
@@ -2,14 +2,11 @@
 <glyph name="ecircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00EA"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
   <outline>
     <component base="e"/>
-    <component base="circumflexcomb"/>
+    <component base="circumflexcomb" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:38:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/edieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/edieresis.glif
@@ -2,14 +2,11 @@
 <glyph name="edieresis" format="2">
   <advance width="620"/>
   <unicode hex="00EB"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="760" name="top"/>
   <outline>
     <component base="e"/>
     <component base="dieresiscomb"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:38:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/egrave.glif
+++ b/0xProto-Regular.ufo/glyphs/egrave.glif
@@ -2,14 +2,11 @@
 <glyph name="egrave" format="2">
   <advance width="620"/>
   <unicode hex="00E8"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
   <outline>
     <component base="e"/>
-    <component base="gravecomb"/>
+    <component base="gravecomb" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 07:38:54</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/eight.glif
+++ b/0xProto-Regular.ufo/glyphs/eight.glif
@@ -58,10 +58,4 @@
       <point x="185" y="458"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:22:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal.glif
@@ -16,10 +16,4 @@
       <point x="545" y="366" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 01:14:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/equal.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_colon_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_colon_equal.glif
@@ -55,10 +55,4 @@
       <point x="-570" y="359" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:59:01</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_equal.glif
@@ -27,10 +27,4 @@
       <point x="504" y="366" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:07:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_equal_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_equal_equal.glif
@@ -39,10 +39,4 @@
       <point x="474" y="366" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:07:39</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_exclam_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_exclam_equal.glif
@@ -51,10 +51,4 @@
       <point x="-228" y="725" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:54:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_greater.glif
@@ -29,10 +29,4 @@
       <point x="70" y="90" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:07:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_greater_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_greater_equal.glif
@@ -41,10 +41,4 @@
       <point x="-520" y="356" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:08:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_greater_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_greater_greater.glif
@@ -43,10 +43,4 @@
       <point x="0" y="85" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:11:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_less_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_less_equal.glif
@@ -41,10 +41,4 @@
       <point x="430" y="428" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:11:51</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/equal_less_less.glif
+++ b/0xProto-Regular.ufo/glyphs/equal_less_less.glif
@@ -43,10 +43,4 @@
       <point x="50" y="-12" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:12:04</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/eth.glif
+++ b/0xProto-Regular.ufo/glyphs/eth.glif
@@ -45,10 +45,4 @@
       <point x="439" y="755" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:47:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/exclam.glif
+++ b/0xProto-Regular.ufo/glyphs/exclam.glif
@@ -28,10 +28,4 @@
       <point x="392" y="725" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:56:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/exclam.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/exclam.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/exclam_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/exclam_equal.glif
@@ -39,10 +39,4 @@
       <point x="-235" y="725" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:57:45</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/exclam_equal_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/exclam_equal_equal.glif
@@ -51,10 +51,4 @@
       <point x="-819" y="725" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:57:30</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/exclamdown.glif
+++ b/0xProto-Regular.ufo/glyphs/exclamdown.glif
@@ -28,10 +28,4 @@
       <point x="235" y="-35"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 12:57:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/f.glif
+++ b/0xProto-Regular.ufo/glyphs/f.glif
@@ -2,6 +2,8 @@
 <glyph name="f" format="2">
   <advance width="620"/>
   <unicode hex="0066"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="750" name="top"/>
   <outline>
     <contour>
       <point x="64" y="489" type="line"/>
@@ -41,10 +43,4 @@
       <point x="344" y="-23" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/16 06:44:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/five.glif
+++ b/0xProto-Regular.ufo/glyphs/five.glif
@@ -44,10 +44,4 @@
       <point x="200" y="330" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:56</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/four.glif
+++ b/0xProto-Regular.ufo/glyphs/four.glif
@@ -27,10 +27,4 @@
       <point x="557" y="158" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:53</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/g.glif
+++ b/0xProto-Regular.ufo/glyphs/g.glif
@@ -2,6 +2,8 @@
 <glyph name="g" format="2">
   <advance width="620"/>
   <unicode hex="0067"/>
+  <anchor x="310" y="-200" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="302" y="265" type="curve" smooth="yes"/>
@@ -77,10 +79,4 @@
       <point x="168" y="-114"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/16 06:48:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/germandbls.glif
+++ b/0xProto-Regular.ufo/glyphs/germandbls.glif
@@ -46,10 +46,4 @@
       <point x="588" y="161"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 06:23:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/grave.glif
+++ b/0xProto-Regular.ufo/glyphs/grave.glif
@@ -11,10 +11,4 @@
       <point x="389" y="462" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/06 03:33:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/gravecomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/gravecomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="gravecomb.case" format="2">
+  <anchor x="291" y="710" name="_top"/>
+  <anchor x="291" y="934" name="top"/>
+  <outline>
+    <component base="gravecomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/gravecomb.glif
+++ b/0xProto-Regular.ufo/glyphs/gravecomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="gravecomb" format="2">
   <unicode hex="0300"/>
+  <anchor x="291" y="550" name="_top"/>
+  <anchor x="291" y="786" name="top"/>
   <outline>
     <contour>
       <point x="287" y="786" type="line"/>
@@ -12,10 +14,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/06 02:48:29</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/greater.glif
+++ b/0xProto-Regular.ufo/glyphs/greater.glif
@@ -18,10 +18,4 @@
       <point x="110" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:23:55</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/greater.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/greater.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/greater_equal_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/greater_equal_greater.glif
@@ -43,10 +43,4 @@
       <point x="-1050" y="85" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:12:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/greater_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/greater_greater.glif
@@ -31,10 +31,4 @@
       <point x="41" y="116" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:12:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/greater_greater_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/greater_greater_greater.glif
@@ -45,10 +45,4 @@
       <point x="-1036" y="116" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:12:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/h.glif
+++ b/0xProto-Regular.ufo/glyphs/h.glif
@@ -2,6 +2,9 @@
 <glyph name="h" format="2">
   <advance width="620"/>
   <unicode hex="0068"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="750" name="top"/>
   <outline>
     <contour>
       <point x="114" y="700" type="line"/>
@@ -38,10 +41,4 @@
       <point x="209" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/hyphen.glif
+++ b/0xProto-Regular.ufo/glyphs/hyphen.glif
@@ -10,10 +10,4 @@
       <point x="530" y="264" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 01:11:02</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/hyphen.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/hyphen.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:51:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/hyphen_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/hyphen_greater.glif
@@ -23,10 +23,4 @@
       <point x="36" y="76" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:41:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/i.glif
+++ b/0xProto-Regular.ufo/glyphs/i.glif
@@ -2,44 +2,11 @@
 <glyph name="i" format="2">
   <advance width="620"/>
   <unicode hex="0069"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="766" name="top"/>
   <outline>
-    <contour>
-      <point x="305" y="606" type="curve" smooth="yes"/>
-      <point x="350" y="606"/>
-      <point x="385" y="641"/>
-      <point x="385" y="686" type="curve" smooth="yes"/>
-      <point x="385" y="730"/>
-      <point x="350" y="766"/>
-      <point x="305" y="766" type="curve" smooth="yes"/>
-      <point x="262" y="766"/>
-      <point x="225" y="730"/>
-      <point x="225" y="686" type="curve" smooth="yes"/>
-      <point x="225" y="641"/>
-      <point x="262" y="606"/>
-    </contour>
-    <contour>
-      <point x="149" y="509" type="line"/>
-      <point x="149" y="421" type="line"/>
-      <point x="382" y="421" type="line"/>
-      <point x="382" y="509" type="line"/>
-    </contour>
-    <contour>
-      <point x="382" y="509" type="line"/>
-      <point x="284" y="509" type="line"/>
-      <point x="284" y="0" type="line"/>
-      <point x="382" y="0" type="line"/>
-    </contour>
-    <contour>
-      <point x="95" y="88" type="line"/>
-      <point x="95" y="0" type="line"/>
-      <point x="543" y="0" type="line"/>
-      <point x="543" y="88" type="line"/>
-    </contour>
+    <component base="idotless"/>
+    <component base="dotaccentcomb"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/iacute.glif
+++ b/0xProto-Regular.ufo/glyphs/iacute.glif
@@ -2,14 +2,11 @@
 <glyph name="iacute" format="2">
   <advance width="620"/>
   <unicode hex="00ED"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="786" name="top"/>
   <outline>
     <component base="idotless"/>
-    <component base="acutecomb"/>
+    <component base="acutecomb" xOffset="-31"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:03:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/icircumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/icircumflex.glif
@@ -2,14 +2,11 @@
 <glyph name="icircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00EE"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="786" name="top"/>
   <outline>
     <component base="idotless"/>
-    <component base="circumflexcomb"/>
+    <component base="circumflexcomb" xOffset="1"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:05:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/idieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/idieresis.glif
@@ -2,14 +2,11 @@
 <glyph name="idieresis" format="2">
   <advance width="620"/>
   <unicode hex="00EF"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="760" name="top"/>
   <outline>
     <component base="idotless"/>
-    <component base="dieresiscomb"/>
+    <component base="dieresiscomb" xOffset="-5"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:06:00</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/idotless.glif
+++ b/0xProto-Regular.ufo/glyphs/idotless.glif
@@ -2,6 +2,9 @@
 <glyph name="idotless" format="2">
   <advance width="620"/>
   <unicode hex="0131"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="550" name="top"/>
   <outline>
     <contour>
       <point x="149" y="509" type="line"/>
@@ -22,10 +25,4 @@
       <point x="543" y="88" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:02:42</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/igrave.glif
+++ b/0xProto-Regular.ufo/glyphs/igrave.glif
@@ -2,14 +2,11 @@
 <glyph name="igrave" format="2">
   <advance width="620"/>
   <unicode hex="00EC"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="543" y="0" name="ogonek"/>
+  <anchor x="305" y="786" name="top"/>
   <outline>
     <component base="idotless"/>
-    <component base="gravecomb"/>
+    <component base="gravecomb" xOffset="14"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 10:06:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/j.glif
+++ b/0xProto-Regular.ufo/glyphs/j.glif
@@ -2,50 +2,10 @@
 <glyph name="j" format="2">
   <advance width="620"/>
   <unicode hex="006A"/>
+  <anchor x="310" y="-200" name="bottom"/>
+  <anchor x="348" y="766" name="top"/>
   <outline>
-    <contour>
-      <point x="141" y="513" type="line"/>
-      <point x="141" y="425" type="line"/>
-      <point x="465" y="425" type="line"/>
-      <point x="465" y="513" type="line"/>
-    </contour>
-    <contour>
-      <point x="465" y="513" type="line"/>
-      <point x="367" y="513" type="line"/>
-      <point x="367" y="7" type="line"/>
-      <point x="465" y="7" type="line"/>
-    </contour>
-    <contour>
-      <point x="348" y="606" type="curve" smooth="yes"/>
-      <point x="393" y="606"/>
-      <point x="428" y="641"/>
-      <point x="428" y="686" type="curve" smooth="yes"/>
-      <point x="428" y="730"/>
-      <point x="393" y="766"/>
-      <point x="348" y="766" type="curve" smooth="yes"/>
-      <point x="305" y="766"/>
-      <point x="268" y="730"/>
-      <point x="268" y="686" type="curve" smooth="yes"/>
-      <point x="268" y="641"/>
-      <point x="305" y="606"/>
-    </contour>
-    <contour>
-      <point x="465" y="7" type="line"/>
-      <point x="465" y="-129"/>
-      <point x="458" y="-200"/>
-      <point x="307" y="-200" type="curve" smooth="yes"/>
-      <point x="83" y="-200" type="line"/>
-      <point x="83" y="-110" type="line"/>
-      <point x="286" y="-110" type="line" smooth="yes"/>
-      <point x="363" y="-110"/>
-      <point x="367" y="-76"/>
-      <point x="367" y="7" type="curve"/>
-    </contour>
+    <component base="jdotless"/>
+    <component base="dotaccentcomb" xOffset="43"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:20</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/jdotless.glif
+++ b/0xProto-Regular.ufo/glyphs/jdotless.glif
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="jdotless" format="2">
+  <advance width="620"/>
+  <unicode hex="0237"/>
+  <anchor x="310" y="-200" name="bottom"/>
+  <anchor x="348" y="550" name="top"/>
+  <outline>
+    <contour>
+      <point x="141" y="513" type="line"/>
+      <point x="141" y="425" type="line"/>
+      <point x="465" y="425" type="line"/>
+      <point x="465" y="513" type="line"/>
+    </contour>
+    <contour>
+      <point x="465" y="513" type="line"/>
+      <point x="367" y="513" type="line"/>
+      <point x="367" y="7" type="line"/>
+      <point x="465" y="7" type="line"/>
+    </contour>
+    <contour>
+      <point x="465" y="7" type="line"/>
+      <point x="465" y="-129"/>
+      <point x="458" y="-200"/>
+      <point x="307" y="-200" type="curve" smooth="yes"/>
+      <point x="83" y="-200" type="line"/>
+      <point x="83" y="-110" type="line"/>
+      <point x="286" y="-110" type="line" smooth="yes"/>
+      <point x="363" y="-110"/>
+      <point x="367" y="-76"/>
+      <point x="367" y="7" type="curve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/k.glif
+++ b/0xProto-Regular.ufo/glyphs/k.glif
@@ -2,6 +2,8 @@
 <glyph name="k" format="2">
   <advance width="620"/>
   <unicode hex="006B"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="750" name="top"/>
   <outline>
     <contour>
       <point x="464" y="0" type="line"/>
@@ -20,10 +22,4 @@
       <point x="257" y="249" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:24</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/l.glif
+++ b/0xProto-Regular.ufo/glyphs/l.glif
@@ -2,6 +2,10 @@
 <glyph name="l" format="2">
   <advance width="620"/>
   <unicode hex="006C"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="750" name="top"/>
+  <anchor x="600" y="750" name="topright"/>
   <outline>
     <contour>
       <point x="212" y="700" type="line"/>
@@ -28,10 +32,4 @@
       <point x="212" y="87"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 11:41:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/layerinfo.plist
+++ b/0xProto-Regular.ufo/glyphs/layerinfo.plist
@@ -122,6 +122,8 @@
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.Z</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.Zcaron</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.a</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.aacute</key>
@@ -129,6 +131,8 @@
       <key>com.schriftgestaltung.layerOrderInGlyph.acircumflex</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.acutecomb</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.acutecomb.case</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.adieresis</key>
       <integer>0</integer>
@@ -450,11 +454,19 @@
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.c</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.caroncomb</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.caroncomb.case</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.ccedilla</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.cedillacomb</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.cedillacomb.case</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.circumflexcomb</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.circumflexcomb.case</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.colon</key>
       <integer>0</integer>
@@ -476,11 +488,17 @@
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.dieresiscomb</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.dieresiscomb.case</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.dollar</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.dollar.spacer</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.dollar_greater</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.dotaccentcomb</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.dotaccentcomb.case</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.e</key>
       <integer>0</integer>
@@ -542,6 +560,8 @@
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.gravecomb</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.gravecomb.case</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.greater</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.greater.spacer</key>
@@ -573,6 +593,8 @@
       <key>com.schriftgestaltung.layerOrderInGlyph.igrave</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.j</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.jdotless</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.k</key>
       <integer>0</integer>
@@ -698,6 +720,8 @@
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.ringcomb</key>
       <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.ringcomb.case</key>
+      <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.s</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.scaron</key>
@@ -723,6 +747,8 @@
       <key>com.schriftgestaltung.layerOrderInGlyph.three</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.tildecomb</key>
+      <integer>0</integer>
+      <key>com.schriftgestaltung.layerOrderInGlyph.tildecomb.case</key>
       <integer>0</integer>
       <key>com.schriftgestaltung.layerOrderInGlyph.two</key>
       <integer>0</integer>

--- a/0xProto-Regular.ufo/glyphs/less.glif
+++ b/0xProto-Regular.ufo/glyphs/less.glif
@@ -18,10 +18,4 @@
       <point x="500" y="11" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 01:13:44</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/less.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 12:39:45</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_asterisk.glif
+++ b/0xProto-Regular.ufo/glyphs/less_asterisk.glif
@@ -47,10 +47,4 @@
       <point x="208" y="309" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:13:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_asterisk_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_asterisk_greater.glif
@@ -61,10 +61,4 @@
       <point x="-27" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:13:26</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_bar.glif
+++ b/0xProto-Regular.ufo/glyphs/less_bar.glif
@@ -23,10 +23,4 @@
       <point x="124" y="-24" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:13:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_bar_bar.glif
+++ b/0xProto-Regular.ufo/glyphs/less_bar_bar.glif
@@ -29,10 +29,4 @@
       <point x="160" y="632" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:14:02</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_bar_bar_bar.glif
+++ b/0xProto-Regular.ufo/glyphs/less_bar_bar_bar.glif
@@ -35,10 +35,4 @@
       <point x="-372" y="632" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:14:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_bar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_bar_greater.glif
@@ -37,10 +37,4 @@
       <point x="-100" y="64" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:14:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_dollar.glif
+++ b/0xProto-Regular.ufo/glyphs/less_dollar.glif
@@ -67,10 +67,4 @@
       <point x="-96" y="11" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:14:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_dollar_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_dollar_greater.glif
@@ -81,10 +81,4 @@
       <point x="20" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:14:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_equal_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_equal_greater.glif
@@ -43,10 +43,4 @@
       <point x="-630" y="-7" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:15:39</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_equal_less.glif
+++ b/0xProto-Regular.ufo/glyphs/less_equal_less.glif
@@ -43,10 +43,4 @@
       <point x="420" y="-12" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:15:52</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_greater.glif
@@ -31,10 +31,4 @@
       <point x="35" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:16:04</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_hyphen.glif
+++ b/0xProto-Regular.ufo/glyphs/less_hyphen.glif
@@ -23,10 +23,4 @@
       <point x="-46" y="-24" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:13:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_less.glif
+++ b/0xProto-Regular.ufo/glyphs/less_less.glif
@@ -31,10 +31,4 @@
       <point x="-51" y="16" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:16:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_less_less.glif
+++ b/0xProto-Regular.ufo/glyphs/less_less_less.glif
@@ -45,10 +45,4 @@
       <point x="406" y="16" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:16:25</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_plus.glif
+++ b/0xProto-Regular.ufo/glyphs/less_plus.glif
@@ -29,10 +29,4 @@
       <point x="186" y="56" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:15:05</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/less_plus_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/less_plus_greater.glif
@@ -43,10 +43,4 @@
       <point x="-27" y="110" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:15:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/m.glif
+++ b/0xProto-Regular.ufo/glyphs/m.glif
@@ -2,6 +2,8 @@
 <glyph name="m" format="2">
   <advance width="620"/>
   <unicode hex="006D"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="36" y="554" type="line"/>
@@ -52,10 +54,4 @@
       <point x="362" y="524"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:30</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/minus.glif
+++ b/0xProto-Regular.ufo/glyphs/minus.glif
@@ -10,10 +10,4 @@
       <point x="550" y="258" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 11:30:46</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/n.glif
+++ b/0xProto-Regular.ufo/glyphs/n.glif
@@ -2,6 +2,8 @@
 <glyph name="n" format="2">
   <advance width="620"/>
   <unicode hex="006E"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="87" y="554" type="line"/>
@@ -30,10 +32,4 @@
       <point x="173" y="554" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:34</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/nine.glif
+++ b/0xProto-Regular.ufo/glyphs/nine.glif
@@ -39,10 +39,4 @@
       <point x="378" y="371"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:22:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ntilde.glif
+++ b/0xProto-Regular.ufo/glyphs/ntilde.glif
@@ -2,14 +2,10 @@
 <glyph name="ntilde" format="2">
   <advance width="620"/>
   <unicode hex="00F1"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="776" name="top"/>
   <outline>
     <component base="n"/>
-    <component base="tildecomb"/>
+    <component base="tildecomb" xOffset="10"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:29:08</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/numbersign.glif
+++ b/0xProto-Regular.ufo/glyphs/numbersign.glif
@@ -28,10 +28,4 @@
       <point x="279" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/02 06:32:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/numbersign.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/numbersign.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/numbersign_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/numbersign_equal.glif
@@ -39,10 +39,4 @@
       <point x="-267" y="0" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:54:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/o.glif
+++ b/0xProto-Regular.ufo/glyphs/o.glif
@@ -2,6 +2,11 @@
 <glyph name="o" format="2">
   <advance width="620"/>
   <unicode hex="006F"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="550" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <contour>
       <point x="310" y="-16" type="curve" smooth="yes"/>
@@ -32,10 +37,4 @@
       <point x="419" y="71"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/oacute.glif
+++ b/0xProto-Regular.ufo/glyphs/oacute.glif
@@ -2,14 +2,13 @@
 <glyph name="oacute" format="2">
   <advance width="620"/>
   <unicode hex="00F3"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="o"/>
-    <component base="acutecomb"/>
+    <component base="acutecomb" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:31:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ocircumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/ocircumflex.glif
@@ -2,14 +2,13 @@
 <glyph name="ocircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00F4"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="o"/>
-    <component base="circumflexcomb"/>
+    <component base="circumflexcomb" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:32:08</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/odieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/odieresis.glif
@@ -2,14 +2,13 @@
 <glyph name="odieresis" format="2">
   <advance width="620"/>
   <unicode hex="00F6"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="760" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="o"/>
     <component base="dieresiscomb"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:32:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/oe.glif
+++ b/0xProto-Regular.ufo/glyphs/oe.glif
@@ -2,6 +2,8 @@
 <glyph name="oe" format="2">
   <advance width="620"/>
   <unicode hex="0153"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="184" y="-16" type="curve" smooth="yes"/>
@@ -63,10 +65,4 @@
       <point x="523" y="312" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 06:23:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ograve.glif
+++ b/0xProto-Regular.ufo/glyphs/ograve.glif
@@ -2,14 +2,13 @@
 <glyph name="ograve" format="2">
   <advance width="620"/>
   <unicode hex="00F2"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="o"/>
-    <component base="gravecomb"/>
+    <component base="gravecomb" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:32:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/one.glif
+++ b/0xProto-Regular.ufo/glyphs/one.glif
@@ -27,10 +27,4 @@
       <point x="354" y="629" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:40</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/oslash.glif
+++ b/0xProto-Regular.ufo/glyphs/oslash.glif
@@ -2,6 +2,11 @@
 <glyph name="oslash" format="2">
   <advance width="620"/>
   <unicode hex="00F8"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="550" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <contour>
       <point x="32" y="-86" type="line"/>
@@ -13,10 +18,4 @@
     </contour>
     <component base="o"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 12:25:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/otilde.glif
+++ b/0xProto-Regular.ufo/glyphs/otilde.glif
@@ -2,14 +2,13 @@
 <glyph name="otilde" format="2">
   <advance width="620"/>
   <unicode hex="00F5"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="776" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="o"/>
-    <component base="tildecomb"/>
+    <component base="tildecomb" xOffset="10"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/01 11:37:39</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/p.glif
+++ b/0xProto-Regular.ufo/glyphs/p.glif
@@ -2,6 +2,8 @@
 <glyph name="p" format="2">
   <advance width="620"/>
   <unicode hex="0070"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="358" y="566" type="curve" smooth="yes"/>
@@ -46,10 +48,4 @@
       <point x="199" y="558" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/parenleft.glif
+++ b/0xProto-Regular.ufo/glyphs/parenleft.glif
@@ -20,10 +20,4 @@
       <point x="239" y="-46"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:55:15</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/parenright.glif
+++ b/0xProto-Regular.ufo/glyphs/parenright.glif
@@ -20,10 +20,4 @@
       <point x="160" y="-51" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:55:09</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/percent.glif
+++ b/0xProto-Regular.ufo/glyphs/percent.glif
@@ -68,10 +68,4 @@
       <point x="394" y="241"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 01:28:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/percent.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/percent.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/percent_percent.glif
+++ b/0xProto-Regular.ufo/glyphs/percent_percent.glif
@@ -131,10 +131,4 @@
       <point x="354" y="241"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 04:16:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/period.glif
+++ b/0xProto-Regular.ufo/glyphs/period.glif
@@ -18,10 +18,4 @@
       <point x="264" y="-19"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:56:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/period.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/period.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/period_equal.glif
+++ b/0xProto-Regular.ufo/glyphs/period_equal.glif
@@ -29,10 +29,4 @@
       <point x="-352" y="-19"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:57:57</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/plus.glif
+++ b/0xProto-Regular.ufo/glyphs/plus.glif
@@ -16,10 +16,4 @@
       <point x="265" y="56" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:24:02</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/plus.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/plus.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 12:14:26</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/plus_greater.glif
+++ b/0xProto-Regular.ufo/glyphs/plus_greater.glif
@@ -29,10 +29,4 @@
       <point x="-276" y="558" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:58:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/q.glif
+++ b/0xProto-Regular.ufo/glyphs/q.glif
@@ -2,6 +2,8 @@
 <glyph name="q" format="2">
   <advance width="620"/>
   <unicode hex="0071"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="423" y="558" type="line"/>
@@ -50,10 +52,4 @@
       <point x="508" y="-23" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:45</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/question.glif
+++ b/0xProto-Regular.ufo/glyphs/question.glif
@@ -42,10 +42,4 @@
       <point x="272" y="-27"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:55:58</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/question.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/question.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:52:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/question_question.glif
+++ b/0xProto-Regular.ufo/glyphs/question_question.glif
@@ -87,10 +87,4 @@
       <point x="159" y="-27"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:57:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/questiondown.glif
+++ b/0xProto-Regular.ufo/glyphs/questiondown.glif
@@ -42,10 +42,4 @@
       <point x="348" y="537"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 12:58:02</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quotedbl.glif
+++ b/0xProto-Regular.ufo/glyphs/quotedbl.glif
@@ -16,10 +16,4 @@
       <point x="477" y="710" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:24:44</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quotedblleft.glif
+++ b/0xProto-Regular.ufo/glyphs/quotedblleft.glif
@@ -44,10 +44,4 @@
       <point x="251" y="578"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:25:41</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quotedblright.glif
+++ b/0xProto-Regular.ufo/glyphs/quotedblright.glif
@@ -44,10 +44,4 @@
       <point x="391" y="588"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:25:44</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quoteleft.glif
+++ b/0xProto-Regular.ufo/glyphs/quoteleft.glif
@@ -24,10 +24,4 @@
       <point x="341" y="578"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:25:35</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quoteright.glif
+++ b/0xProto-Regular.ufo/glyphs/quoteright.glif
@@ -24,10 +24,4 @@
       <point x="274" y="588"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:25:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/quotesingle.glif
+++ b/0xProto-Regular.ufo/glyphs/quotesingle.glif
@@ -10,10 +10,4 @@
       <point x="373" y="710" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/01 14:01:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/r.glif
+++ b/0xProto-Regular.ufo/glyphs/r.glif
@@ -2,6 +2,8 @@
 <glyph name="r" format="2">
   <advance width="620"/>
   <unicode hex="0072"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="264" y="558" type="line"/>
@@ -36,10 +38,4 @@
       <point x="481" y="461"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ringcomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/ringcomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="ringcomb.case" format="2">
+  <anchor x="310" y="710" name="_top"/>
+  <anchor x="310" y="963" name="top"/>
+  <outline>
+    <component base="ringcomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/ringcomb.glif
+++ b/0xProto-Regular.ufo/glyphs/ringcomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="ringcomb" format="2">
   <unicode hex="030A"/>
+  <anchor x="310" y="550" name="_top"/>
+  <anchor x="310" y="815" name="top"/>
   <outline>
     <contour>
       <point x="310" y="611" type="curve" smooth="yes"/>
@@ -33,10 +35,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:40:55</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/s.glif
+++ b/0xProto-Regular.ufo/glyphs/s.glif
@@ -2,6 +2,8 @@
 <glyph name="s" format="2">
   <advance width="620"/>
   <unicode hex="0073"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="83" y="70" type="line"/>
@@ -38,10 +40,4 @@
       <point x="144" y="137" type="curve"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/02 03:42:17</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/scaron.glif
+++ b/0xProto-Regular.ufo/glyphs/scaron.glif
@@ -2,14 +2,10 @@
 <glyph name="scaron" format="2">
   <advance width="620"/>
   <unicode hex="0161"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="786" name="top"/>
   <outline>
     <component base="s"/>
-    <component base="circumflexcomb" yScale="-1" yOffset="1394"/>
+    <component base="caroncomb" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 00:33:06</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/semicolon.glif
+++ b/0xProto-Regular.ufo/glyphs/semicolon.glif
@@ -38,10 +38,4 @@
       <point x="279" y="0"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/29 06:56:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/seven.glif
+++ b/0xProto-Regular.ufo/glyphs/seven.glif
@@ -32,10 +32,4 @@
       <point x="445" y="710" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/30 04:40:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/six.glif
+++ b/0xProto-Regular.ufo/glyphs/six.glif
@@ -39,10 +39,4 @@
       <point x="240" y="340"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:22:01</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/slash.glif
+++ b/0xProto-Regular.ufo/glyphs/slash.glif
@@ -12,10 +12,4 @@
       <point x="473" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/03 07:39:31</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/slash.spacer.glif
+++ b/0xProto-Regular.ufo/glyphs/slash.spacer.glif
@@ -3,10 +3,4 @@
   <advance width="620"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 03:27:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/slash_slash.glif
+++ b/0xProto-Regular.ufo/glyphs/slash_slash.glif
@@ -19,10 +19,4 @@
       <point x="390" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:55:01</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/slash_slash_slash.glif
+++ b/0xProto-Regular.ufo/glyphs/slash_slash_slash.glif
@@ -27,10 +27,4 @@
       <point x="340" y="750" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/26 03:55:14</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/space.glif
+++ b/0xProto-Regular.ufo/glyphs/space.glif
@@ -4,10 +4,4 @@
   <unicode hex="0020"/>
   <outline>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/14 07:04:18</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/t.glif
+++ b/0xProto-Regular.ufo/glyphs/t.glif
@@ -2,6 +2,10 @@
 <glyph name="t" format="2">
   <advance width="620"/>
   <unicode hex="0074"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="550" name="top"/>
+  <anchor x="600" y="750" name="topright"/>
   <outline>
     <contour>
       <point x="71" y="550" type="line"/>
@@ -24,10 +28,4 @@
       <point x="323" y="177" type="curve" smooth="yes"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/09/16 06:45:12</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/three.glif
+++ b/0xProto-Regular.ufo/glyphs/three.glif
@@ -51,10 +51,4 @@
       <point x="534" y="272"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/30 14:48:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/tildecomb.case.glif
+++ b/0xProto-Regular.ufo/glyphs/tildecomb.case.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="tildecomb.case" format="2">
+  <anchor x="300" y="710" name="_top"/>
+  <anchor x="300" y="924" name="top"/>
+  <outline>
+    <component base="tildecomb" yOffset="148"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.originalWidth</key>
+      <integer>620</integer>
+    </dict>
+  </lib>
+</glyph>

--- a/0xProto-Regular.ufo/glyphs/tildecomb.glif
+++ b/0xProto-Regular.ufo/glyphs/tildecomb.glif
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="tildecomb" format="2">
   <unicode hex="0303"/>
+  <anchor x="300" y="550" name="_top"/>
+  <anchor x="300" y="776" name="top"/>
   <outline>
     <contour>
       <point x="320" y="727" type="curve" smooth="yes"/>
@@ -21,10 +23,6 @@
   </outline>
   <lib>
     <dict>
-      <key>com.schriftgestaltung.Glyphs.Export</key>
-      <false/>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/05 07:44:04</string>
       <key>com.schriftgestaltung.Glyphs.originalWidth</key>
       <integer>620</integer>
     </dict>

--- a/0xProto-Regular.ufo/glyphs/two.glif
+++ b/0xProto-Regular.ufo/glyphs/two.glif
@@ -34,10 +34,4 @@
       <point x="147" y="687"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:47</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/u.glif
+++ b/0xProto-Regular.ufo/glyphs/u.glif
@@ -2,6 +2,10 @@
 <glyph name="u" format="2">
   <advance width="620"/>
   <unicode hex="0075"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="550" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <contour>
       <point x="433" y="70" type="line"/>
@@ -35,10 +39,4 @@
       <point x="176" y="550" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:20:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/uacute.glif
+++ b/0xProto-Regular.ufo/glyphs/uacute.glif
@@ -2,14 +2,12 @@
 <glyph name="uacute" format="2">
   <advance width="620"/>
   <unicode hex="00FA"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="u"/>
-    <component base="acutecomb"/>
+    <component base="acutecomb" xOffset="-26"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:49:28</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ucircumflex.glif
+++ b/0xProto-Regular.ufo/glyphs/ucircumflex.glif
@@ -2,14 +2,12 @@
 <glyph name="ucircumflex" format="2">
   <advance width="620"/>
   <unicode hex="00FB"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="u"/>
-    <component base="circumflexcomb"/>
+    <component base="circumflexcomb" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:49:36</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/udieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/udieresis.glif
@@ -2,14 +2,12 @@
 <glyph name="udieresis" format="2">
   <advance width="620"/>
   <unicode hex="00FC"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="760" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="u"/>
-    <component base="dieresiscomb" xOffset="-12"/>
+    <component base="dieresiscomb"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 04:26:23</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ugrave.glif
+++ b/0xProto-Regular.ufo/glyphs/ugrave.glif
@@ -2,14 +2,12 @@
 <glyph name="ugrave" format="2">
   <advance width="620"/>
   <unicode hex="00F9"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="558" y="10" name="ogonek"/>
+  <anchor x="310" y="786" name="top"/>
+  <anchor x="600" y="550" name="topright"/>
   <outline>
     <component base="u"/>
-    <component base="gravecomb"/>
+    <component base="gravecomb" xOffset="19"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:49:50</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/underscore.glif
+++ b/0xProto-Regular.ufo/glyphs/underscore.glif
@@ -10,10 +10,4 @@
       <point x="553" y="-86" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 01:07:27</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/v.glif
+++ b/0xProto-Regular.ufo/glyphs/v.glif
@@ -2,6 +2,8 @@
 <glyph name="v" format="2">
   <advance width="620"/>
   <unicode hex="0076"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="57" y="550" type="line"/>
@@ -24,10 +26,4 @@
       <point x="494" y="267"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:03</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/w.glif
+++ b/0xProto-Regular.ufo/glyphs/w.glif
@@ -2,6 +2,8 @@
 <glyph name="w" format="2">
   <advance width="620"/>
   <unicode hex="0077"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="41" y="550" type="line"/>
@@ -36,10 +38,4 @@
       <point x="572" y="307"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/27 08:54:37</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/x.glif
+++ b/0xProto-Regular.ufo/glyphs/x.glif
@@ -2,6 +2,8 @@
 <glyph name="x" format="2">
   <advance width="620"/>
   <unicode hex="0078"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="81" y="0" type="line"/>
@@ -32,10 +34,4 @@
       <point x="431" y="550" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:10</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/y.glif
+++ b/0xProto-Regular.ufo/glyphs/y.glif
@@ -42,10 +42,4 @@
       <point x="225" y="545" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:21:16</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/yacute.glif
+++ b/0xProto-Regular.ufo/glyphs/yacute.glif
@@ -6,10 +6,4 @@
     <component base="y"/>
     <component base="acutecomb"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:53:49</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/ydieresis.glif
+++ b/0xProto-Regular.ufo/glyphs/ydieresis.glif
@@ -6,10 +6,4 @@
     <component base="y"/>
     <component base="dieresiscomb" xOffset="13"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 04:26:11</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/z.glif
+++ b/0xProto-Regular.ufo/glyphs/z.glif
@@ -2,6 +2,9 @@
 <glyph name="z" format="2">
   <advance width="620"/>
   <unicode hex="007A"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="550" name="top"/>
   <outline>
     <contour>
       <point x="91" y="550" type="line"/>
@@ -22,10 +25,4 @@
       <point x="393" y="462" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/04/27 12:56:59</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/zcaron.glif
+++ b/0xProto-Regular.ufo/glyphs/zcaron.glif
@@ -2,14 +2,11 @@
 <glyph name="zcaron" format="2">
   <advance width="620"/>
   <unicode hex="017E"/>
+  <anchor x="310" y="0" name="bottom"/>
+  <anchor x="310" y="275" name="center"/>
+  <anchor x="310" y="786" name="top"/>
   <outline>
     <component base="z"/>
-    <component base="circumflexcomb" yScale="-1" xOffset="14" yOffset="1394"/>
+    <component base="caroncomb" xOffset="6"/>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/11/02 02:55:38</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/glyphs/zero.glif
+++ b/0xProto-Regular.ufo/glyphs/zero.glif
@@ -38,10 +38,4 @@
       <point x="415" y="602" type="line"/>
     </contour>
   </outline>
-  <lib>
-    <dict>
-      <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2023/05/04 05:22:13</string>
-    </dict>
-  </lib>
 </glyph>

--- a/0xProto-Regular.ufo/lib.plist
+++ b/0xProto-Regular.ufo/lib.plist
@@ -17,6 +17,8 @@
     </array>
     <key>com.schriftgestaltung.appVersion</key>
     <string>3151</string>
+    <key>com.schriftgestaltung.customParameter.GSFont.Write lastChange</key>
+    <integer>0</integer>
     <key>com.schriftgestaltung.customParameter.GSFont.disablesAutomaticAlignment</key>
     <false/>
     <key>com.schriftgestaltung.customParameter.GSFont.useNiceNames</key>
@@ -109,6 +111,7 @@
       <string>Yacute</string>
       <string>Ydieresis</string>
       <string>Z</string>
+      <string>Zcaron</string>
       <string>a</string>
       <string>aacute</string>
       <string>acircumflex</string>
@@ -137,6 +140,7 @@
       <string>idieresis</string>
       <string>igrave</string>
       <string>j</string>
+      <string>jdotless</string>
       <string>k</string>
       <string>l</string>
       <string>m</string>
@@ -419,12 +423,23 @@
       <string>boxVerticalSingleAndRightDouble</string>
       <string>boxLeftDownHeavyAndRightUpLight.001</string>
       <string>dieresiscomb</string>
+      <string>dotaccentcomb</string>
       <string>gravecomb</string>
       <string>acutecomb</string>
       <string>circumflexcomb</string>
+      <string>caroncomb</string>
       <string>ringcomb</string>
       <string>tildecomb</string>
       <string>cedillacomb</string>
+      <string>dieresiscomb.case</string>
+      <string>dotaccentcomb.case</string>
+      <string>gravecomb.case</string>
+      <string>acutecomb.case</string>
+      <string>circumflexcomb.case</string>
+      <string>caroncomb.case</string>
+      <string>ringcomb.case</string>
+      <string>tildecomb.case</string>
+      <string>cedillacomb.case</string>
       <string>grave</string>
     </array>
     <key>public.postscriptNames</key>
@@ -685,16 +700,34 @@
       <string>uni2561</string>
       <key>boxVerticalSingleAndRightDouble</key>
       <string>uni255E</string>
+      <key>caroncomb</key>
+      <string>uni030C</string>
+      <key>caroncomb.case</key>
+      <string>uni030C.case</string>
       <key>cedillacomb</key>
       <string>uni0327</string>
+      <key>cedillacomb.case</key>
+      <string>uni0327.case</string>
       <key>circumflexcomb</key>
       <string>uni0302</string>
+      <key>circumflexcomb.case</key>
+      <string>uni0302.case</string>
       <key>dieresiscomb</key>
       <string>uni0308</string>
+      <key>dieresiscomb.case</key>
+      <string>uni0308.case</string>
+      <key>dotaccentcomb</key>
+      <string>uni0307</string>
+      <key>dotaccentcomb.case</key>
+      <string>uni0307.case</string>
       <key>idotless</key>
       <string>dotlessi</string>
+      <key>jdotless</key>
+      <string>uni0237</string>
       <key>ringcomb</key>
       <string>uni030A</string>
+      <key>ringcomb.case</key>
+      <string>uni030A.case</string>
     </dict>
   </dict>
 </plist>

--- a/0xProto.glyphs
+++ b/0xProto.glyphs
@@ -19323,7 +19323,6 @@ GSDimensionPlugin.Dimensions = {
 m01 = {
 };
 };
-GSDontShowVersionAlert = 1;
 };
 versionMajor = 1;
 versionMinor = 400;

--- a/0xProto.glyphs
+++ b/0xProto.glyphs
@@ -1,6 +1,13 @@
 {
 .appVersion = "3151";
 .formatVersion = 3;
+classes = (
+{
+automatic = 1;
+code = "A Aacute Acircumflex Adieresis Agrave Aring Atilde AE B C Ccedilla D Eth E Eacute Ecircumflex Edieresis Egrave F G H I Iacute Icircumflex Idieresis Igrave J K L M N Ntilde O Oacute Ocircumflex Odieresis Ograve Oslash Otilde OE P Q R S Scaron T U Uacute Ucircumflex Udieresis Ugrave V W X Y Yacute Ydieresis Z Zcaron";
+name = Uppercase;
+}
+);
 customParameters = (
 {
 name = isFixedPitch;
@@ -20,6 +27,10 @@ value = (
 0,
 0
 );
+},
+{
+name = "Write lastChange";
+value = 0;
 }
 );
 date = "2023-06-01 01:15:37 +0000";
@@ -481,6 +492,29 @@ code = "# lookupflag IgnoreMarks;
 ";
 disabled = 1;
 tag = liga;
+},
+{
+automatic = 1;
+code = "lookup ccmp_Other_1 {
+	@CombiningTopAccents = [acutecomb caroncomb circumflexcomb dieresiscomb dotaccentcomb gravecomb ringcomb tildecomb];
+	lookupflag UseMarkFilteringSet @CombiningTopAccents;
+	sub i' @CombiningTopAccents by idotless;
+	sub j' @CombiningTopAccents by jdotless;
+} ccmp_Other_1;
+
+lookup ccmp_Other_2 {
+	@Markscomb = [dieresiscomb dotaccentcomb gravecomb acutecomb circumflexcomb caroncomb ringcomb tildecomb cedillacomb];
+	@MarkscombCase = [dieresiscomb.case dotaccentcomb.case gravecomb.case acutecomb.case circumflexcomb.case caroncomb.case ringcomb.case tildecomb.case cedillacomb.case];
+	sub @Markscomb @Markscomb' by @MarkscombCase;
+	sub @Uppercase @Markscomb' by @MarkscombCase;
+} ccmp_Other_2;
+
+lookup ccmp_Other_3 {
+	sub @Markscomb' @MarkscombCase by @MarkscombCase;
+	sub @MarkscombCase @Markscomb' by @MarkscombCase;
+} ccmp_Other_3;
+";
+tag = ccmp;
 }
 );
 fontMaster = (
@@ -503,7 +537,6 @@ over = -16;
 pos = -200;
 },
 {
-over = -16;
 },
 {
 over = 16;
@@ -520,9 +553,22 @@ visible = 1;
 glyphs = (
 {
 glyphname = A;
-lastChange = "2023-04-28 07:57:06 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -568,7 +614,6 @@ unicode = 65;
 },
 {
 glyphname = Aacute;
-lastChange = "2023-10-31 07:21:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -577,8 +622,8 @@ shapes = (
 ref = A;
 },
 {
-pos = (-1,148);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -588,7 +633,6 @@ unicode = 193;
 },
 {
 glyphname = Acircumflex;
-lastChange = "2023-10-31 07:28:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -597,8 +641,8 @@ shapes = (
 ref = A;
 },
 {
-pos = (0,148);
-ref = circumflexcomb;
+pos = (6,0);
+ref = circumflexcomb.case;
 }
 );
 width = 620;
@@ -608,49 +652,15 @@ unicode = 194;
 },
 {
 glyphname = Adieresis;
-lastChange = "2023-10-31 07:30:23 +0000";
 layers = (
 {
 layerId = m01;
 shapes = (
 {
-closed = 1;
-nodes = (
-(139,0,l),
-(207,304,o),
-(270,540,o),
-(352,710,c),
-(258,710,l),
-(176,540,o),
-(106,304,o),
-(38,0,c)
-);
+ref = A;
 },
 {
-closed = 1;
-nodes = (
-(514,304,o),
-(444,540,o),
-(362,710,c),
-(268,710,l),
-(350,540,o),
-(413,304,o),
-(481,0,c),
-(582,0,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(164,170,l),
-(464,170,l),
-(464,258,l),
-(164,258,l)
-);
-},
-{
-pos = (-1,122);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -660,7 +670,6 @@ unicode = 196;
 },
 {
 glyphname = Agrave;
-lastChange = "2023-10-31 07:31:04 +0000";
 layers = (
 {
 layerId = m01;
@@ -669,8 +678,8 @@ shapes = (
 ref = A;
 },
 {
-pos = (-8,148);
-ref = gravecomb;
+pos = (19,0);
+ref = gravecomb.case;
 }
 );
 width = 620;
@@ -680,7 +689,6 @@ unicode = 192;
 },
 {
 glyphname = Aring;
-lastChange = "2023-10-31 07:32:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -689,8 +697,7 @@ shapes = (
 ref = A;
 },
 {
-pos = (0,149);
-ref = ringcomb;
+ref = ringcomb.case;
 }
 );
 width = 620;
@@ -700,7 +707,6 @@ unicode = 197;
 },
 {
 glyphname = Atilde;
-lastChange = "2023-10-31 07:32:34 +0000";
 layers = (
 {
 layerId = m01;
@@ -709,8 +715,8 @@ shapes = (
 ref = A;
 },
 {
-pos = (20,142);
-ref = tildecomb;
+pos = (10,0);
+ref = tildecomb.case;
 }
 );
 width = 620;
@@ -720,7 +726,6 @@ unicode = 195;
 },
 {
 glyphname = AE;
-lastChange = "2023-11-05 06:23:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -857,9 +862,22 @@ unicode = 198;
 },
 {
 glyphname = B;
-lastChange = "2023-05-03 02:04:16 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -941,9 +959,18 @@ unicode = 66;
 },
 {
 glyphname = C;
-lastChange = "2023-05-04 05:17:37 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -985,7 +1012,6 @@ unicode = 67;
 },
 {
 glyphname = Ccedilla;
-lastChange = "2023-11-02 07:00:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -994,7 +1020,8 @@ shapes = (
 ref = C;
 },
 {
-ref = cedillacomb;
+pos = (-15,0);
+ref = cedillacomb.case;
 }
 );
 width = 620;
@@ -1004,9 +1031,22 @@ unicode = 199;
 },
 {
 glyphname = D;
-lastChange = "2023-04-28 07:59:52 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1057,7 +1097,6 @@ unicode = 68;
 },
 {
 glyphname = Eth;
-lastChange = "2023-11-02 07:35:11 +0000";
 layers = (
 {
 layerId = m01;
@@ -1119,9 +1158,26 @@ unicode = 208;
 },
 {
 glyphname = E;
-lastChange = "2023-05-02 01:25:55 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topleft;
+pos = (20,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1168,7 +1224,6 @@ unicode = 69;
 },
 {
 glyphname = Eacute;
-lastChange = "2023-11-01 07:45:18 +0000";
 layers = (
 {
 layerId = m01;
@@ -1177,8 +1232,8 @@ shapes = (
 ref = E;
 },
 {
-pos = (0,132);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -1188,7 +1243,6 @@ unicode = 201;
 },
 {
 glyphname = Ecircumflex;
-lastChange = "2023-11-01 07:48:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -1197,8 +1251,8 @@ shapes = (
 ref = E;
 },
 {
-pos = (10,148);
-ref = circumflexcomb;
+pos = (6,0);
+ref = circumflexcomb.case;
 }
 );
 width = 620;
@@ -1208,7 +1262,6 @@ unicode = 202;
 },
 {
 glyphname = Edieresis;
-lastChange = "2023-11-01 09:59:32 +0000";
 layers = (
 {
 layerId = m01;
@@ -1217,8 +1270,7 @@ shapes = (
 ref = E;
 },
 {
-pos = (11,122);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -1228,7 +1280,6 @@ unicode = 203;
 },
 {
 glyphname = Egrave;
-lastChange = "2023-11-01 07:49:35 +0000";
 layers = (
 {
 layerId = m01;
@@ -1237,8 +1288,8 @@ shapes = (
 ref = E;
 },
 {
-pos = (0,148);
-ref = gravecomb;
+pos = (19,0);
+ref = gravecomb.case;
 }
 );
 width = 620;
@@ -1248,9 +1299,18 @@ unicode = 200;
 },
 {
 glyphname = F;
-lastChange = "2023-05-02 01:26:18 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1288,9 +1348,18 @@ unicode = 70;
 },
 {
 glyphname = G;
-lastChange = "2023-05-04 05:17:47 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1343,9 +1412,26 @@ unicode = 71;
 },
 {
 glyphname = H;
-lastChange = "2023-05-04 05:17:57 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topleft;
+pos = (20,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1383,9 +1469,26 @@ unicode = 72;
 },
 {
 glyphname = I;
-lastChange = "2023-04-26 15:20:13 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topleft;
+pos = (20,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1423,7 +1526,6 @@ unicode = 73;
 },
 {
 glyphname = Iacute;
-lastChange = "2023-11-01 10:09:53 +0000";
 layers = (
 {
 layerId = m01;
@@ -1432,8 +1534,8 @@ shapes = (
 ref = I;
 },
 {
-pos = (-17,148);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -1443,7 +1545,6 @@ unicode = 205;
 },
 {
 glyphname = Icircumflex;
-lastChange = "2023-11-05 07:43:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -1452,8 +1553,8 @@ shapes = (
 ref = I;
 },
 {
-pos = (0,148);
-ref = circumflexcomb;
+pos = (6,0);
+ref = circumflexcomb.case;
 }
 );
 width = 620;
@@ -1463,7 +1564,6 @@ unicode = 206;
 },
 {
 glyphname = Idieresis;
-lastChange = "2023-11-01 10:09:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -1472,8 +1572,7 @@ shapes = (
 ref = I;
 },
 {
-pos = (0,122);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -1483,7 +1582,6 @@ unicode = 207;
 },
 {
 glyphname = Igrave;
-lastChange = "2023-11-01 10:09:43 +0000";
 layers = (
 {
 layerId = m01;
@@ -1492,8 +1590,8 @@ shapes = (
 ref = I;
 },
 {
-pos = (9,148);
-ref = gravecomb;
+pos = (19,0);
+ref = gravecomb.case;
 }
 );
 width = 620;
@@ -1503,9 +1601,18 @@ unicode = 204;
 },
 {
 glyphname = J;
-lastChange = "2023-05-04 05:18:03 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1553,9 +1660,18 @@ unicode = 74;
 },
 {
 glyphname = K;
-lastChange = "2023-05-04 05:18:06 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1585,9 +1701,26 @@ unicode = 75;
 },
 {
 glyphname = L;
-lastChange = "2023-05-03 07:34:57 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topright;
+pos = (600,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1616,9 +1749,18 @@ unicode = 76;
 },
 {
 glyphname = M;
-lastChange = "2023-05-04 05:18:11 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -1674,9 +1816,18 @@ unicode = 77;
 },
 {
 glyphname = N;
-lastChange = "2023-05-04 05:18:14 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -1715,7 +1866,6 @@ unicode = 78;
 },
 {
 glyphname = Ntilde;
-lastChange = "2023-11-01 11:28:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -1724,8 +1874,8 @@ shapes = (
 ref = N;
 },
 {
-pos = (16,142);
-ref = tildecomb;
+pos = (10,0);
+ref = tildecomb.case;
 }
 );
 width = 620;
@@ -1735,9 +1885,34 @@ unicode = 209;
 },
 {
 glyphname = O;
-lastChange = "2023-05-04 05:18:32 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topleft;
+pos = (20,710);
+},
+{
+name = topright;
+pos = (600,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -1782,7 +1957,6 @@ unicode = 79;
 },
 {
 glyphname = Oacute;
-lastChange = "2023-11-01 12:26:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -1791,8 +1965,8 @@ shapes = (
 ref = O;
 },
 {
-pos = (0,147);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -1802,7 +1976,6 @@ unicode = 211;
 },
 {
 glyphname = Ocircumflex;
-lastChange = "2023-11-01 12:26:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -1811,8 +1984,8 @@ shapes = (
 ref = O;
 },
 {
-pos = (0,147);
-ref = circumflexcomb;
+pos = (6,0);
+ref = circumflexcomb.case;
 }
 );
 width = 620;
@@ -1822,7 +1995,6 @@ unicode = 212;
 },
 {
 glyphname = Odieresis;
-lastChange = "2023-11-01 12:26:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -1831,8 +2003,7 @@ shapes = (
 ref = O;
 },
 {
-pos = (0,123);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -1842,7 +2013,6 @@ unicode = 214;
 },
 {
 glyphname = Ograve;
-lastChange = "2023-11-01 12:27:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -1851,8 +2021,8 @@ shapes = (
 ref = O;
 },
 {
-pos = (0,148);
-ref = gravecomb;
+pos = (19,0);
+ref = gravecomb.case;
 }
 );
 width = 620;
@@ -1862,7 +2032,6 @@ unicode = 210;
 },
 {
 glyphname = Oslash;
-lastChange = "2023-11-01 12:25:42 +0000";
 layers = (
 {
 layerId = m01;
@@ -1889,7 +2058,6 @@ unicode = 216;
 },
 {
 glyphname = Otilde;
-lastChange = "2023-11-01 12:28:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -1898,8 +2066,8 @@ shapes = (
 ref = O;
 },
 {
-pos = (1,141);
-ref = tildecomb;
+pos = (10,0);
+ref = tildecomb.case;
 }
 );
 width = 620;
@@ -1909,9 +2077,18 @@ unicode = 213;
 },
 {
 glyphname = OE;
-lastChange = "2023-11-05 06:23:57 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2066,9 +2243,18 @@ unicode = 338;
 },
 {
 glyphname = P;
-lastChange = "2023-05-03 07:35:21 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2119,9 +2305,18 @@ unicode = 80;
 },
 {
 glyphname = Q;
-lastChange = "2023-05-28 05:44:36 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -2188,9 +2383,18 @@ unicode = 81;
 },
 {
 glyphname = R;
-lastChange = "2023-05-04 05:18:43 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2251,9 +2455,18 @@ unicode = 82;
 },
 {
 glyphname = S;
-lastChange = "2023-05-03 07:35:43 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2301,7 +2514,6 @@ unicode = 83;
 },
 {
 glyphname = Scaron;
-lastChange = "2023-11-02 00:32:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -2310,9 +2522,8 @@ shapes = (
 ref = S;
 },
 {
-pos = (0,1542);
-ref = circumflexcomb;
-scale = (1,-1);
+pos = (6,0);
+ref = caroncomb.case;
 }
 );
 width = 620;
@@ -2322,9 +2533,22 @@ unicode = 352;
 },
 {
 glyphname = T;
-lastChange = "2023-05-04 05:18:48 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,355);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2353,9 +2577,26 @@ unicode = 84;
 },
 {
 glyphname = U;
-lastChange = "2023-04-27 02:48:30 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topright;
+pos = (600,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2389,7 +2630,6 @@ unicode = 85;
 },
 {
 glyphname = Uacute;
-lastChange = "2023-11-02 02:51:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -2398,8 +2638,8 @@ shapes = (
 ref = U;
 },
 {
-pos = (0,148);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -2409,7 +2649,6 @@ unicode = 218;
 },
 {
 glyphname = Ucircumflex;
-lastChange = "2023-11-02 02:51:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -2418,8 +2657,8 @@ shapes = (
 ref = U;
 },
 {
-pos = (0,148);
-ref = circumflexcomb;
+pos = (6,0);
+ref = circumflexcomb.case;
 }
 );
 width = 620;
@@ -2429,7 +2668,6 @@ unicode = 219;
 },
 {
 glyphname = Udieresis;
-lastChange = "2023-11-02 02:51:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -2438,8 +2676,7 @@ shapes = (
 ref = U;
 },
 {
-pos = (0,122);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -2449,7 +2686,6 @@ unicode = 220;
 },
 {
 glyphname = Ugrave;
-lastChange = "2023-11-02 02:52:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -2458,8 +2694,8 @@ shapes = (
 ref = U;
 },
 {
-pos = (0,148);
-ref = gravecomb;
+pos = (19,0);
+ref = gravecomb.case;
 }
 );
 width = 620;
@@ -2469,9 +2705,18 @@ unicode = 217;
 },
 {
 glyphname = V;
-lastChange = "2023-05-04 05:18:55 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2508,9 +2753,18 @@ unicode = 86;
 },
 {
 glyphname = W;
-lastChange = "2023-05-04 05:18:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2565,9 +2819,18 @@ unicode = 87;
 },
 {
 glyphname = X;
-lastChange = "2023-05-04 05:19:04 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2618,9 +2881,22 @@ unicode = 88;
 },
 {
 glyphname = Y;
-lastChange = "2023-04-28 04:11:54 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,710);
+},
+{
+name = topleft;
+pos = (20,710);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2660,7 +2936,6 @@ unicode = 89;
 },
 {
 glyphname = Yacute;
-lastChange = "2023-11-02 02:53:29 +0000";
 layers = (
 {
 layerId = m01;
@@ -2669,8 +2944,8 @@ shapes = (
 ref = Y;
 },
 {
-pos = (0,148);
-ref = acutecomb;
+pos = (-26,0);
+ref = acutecomb.case;
 }
 );
 width = 620;
@@ -2680,7 +2955,6 @@ unicode = 221;
 },
 {
 glyphname = Ydieresis;
-lastChange = "2023-11-02 02:53:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -2689,8 +2963,7 @@ shapes = (
 ref = Y;
 },
 {
-pos = (0,122);
-ref = dieresiscomb;
+ref = dieresiscomb.case;
 }
 );
 width = 620;
@@ -2700,7 +2973,6 @@ unicode = 376;
 },
 {
 glyphname = Z;
-lastChange = "2023-04-27 02:49:46 +0000";
 layers = (
 {
 layerId = m01;
@@ -2739,10 +3011,41 @@ width = 620;
 unicode = 90;
 },
 {
-glyphname = a;
-lastChange = "2023-10-27 11:12:22 +0000";
+glyphname = Zcaron;
 layers = (
 {
+layerId = m01;
+shapes = (
+{
+ref = Z;
+},
+{
+ref = caroncomb.case;
+}
+);
+width = 620;
+}
+);
+unicode = 381;
+},
+{
+glyphname = a;
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (295,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -2804,7 +3107,6 @@ unicode = 97;
 },
 {
 glyphname = aacute;
-lastChange = "2023-10-27 11:18:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -2813,6 +3115,7 @@ shapes = (
 ref = a;
 },
 {
+pos = (-41,0);
 ref = acutecomb;
 }
 );
@@ -2823,7 +3126,6 @@ unicode = 225;
 },
 {
 glyphname = acircumflex;
-lastChange = "2023-10-29 06:59:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -2843,7 +3145,6 @@ unicode = 226;
 },
 {
 glyphname = adieresis;
-lastChange = "2023-10-31 07:29:33 +0000";
 layers = (
 {
 layerId = m01;
@@ -2852,6 +3153,7 @@ shapes = (
 ref = a;
 },
 {
+pos = (-15,0);
 ref = dieresiscomb;
 }
 );
@@ -2862,7 +3164,6 @@ unicode = 228;
 },
 {
 glyphname = agrave;
-lastChange = "2023-10-27 11:12:22 +0000";
 layers = (
 {
 layerId = m01;
@@ -2882,7 +3183,6 @@ unicode = 224;
 },
 {
 glyphname = aring;
-lastChange = "2023-10-31 07:31:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -2891,7 +3191,7 @@ shapes = (
 ref = a;
 },
 {
-pos = (-1,0);
+pos = (-15,0);
 ref = ringcomb;
 }
 );
@@ -2902,7 +3202,6 @@ unicode = 229;
 },
 {
 glyphname = atilde;
-lastChange = "2023-11-06 02:46:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -2912,7 +3211,7 @@ shapes = (
 ref = a;
 },
 {
-pos = (6,1);
+pos = (-5,0);
 ref = tildecomb;
 }
 );
@@ -2973,7 +3272,6 @@ unicode = 227;
 },
 {
 glyphname = ae;
-lastChange = "2023-11-06 02:51:43 +0000";
 layers = (
 {
 layerId = m01;
@@ -3313,9 +3611,22 @@ unicode = 230;
 },
 {
 glyphname = b;
-lastChange = "2023-05-04 05:19:49 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -3379,9 +3690,18 @@ unicode = 98;
 },
 {
 glyphname = c;
-lastChange = "2023-05-04 05:19:53 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -3424,7 +3744,6 @@ unicode = 99;
 },
 {
 glyphname = ccedilla;
-lastChange = "2023-11-02 06:59:10 +0000";
 layers = (
 {
 layerId = m01;
@@ -3434,7 +3753,7 @@ shapes = (
 ref = c;
 },
 {
-pos = (-11,0);
+pos = (-15,0);
 ref = cedillacomb;
 }
 );
@@ -3493,9 +3812,26 @@ unicode = 231;
 },
 {
 glyphname = d;
-lastChange = "2023-05-04 05:19:57 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,550);
+},
+{
+name = topright;
+pos = (600,750);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -3560,7 +3896,6 @@ unicode = 100;
 },
 {
 glyphname = eth;
-lastChange = "2023-11-05 07:47:57 +0000";
 layers = (
 {
 layerId = m01;
@@ -3859,9 +4194,22 @@ unicode = 240;
 },
 {
 glyphname = e;
-lastChange = "2023-05-04 05:20:01 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -3910,7 +4258,6 @@ unicode = 101;
 },
 {
 glyphname = eacute;
-lastChange = "2023-11-01 07:37:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -3919,6 +4266,7 @@ shapes = (
 ref = e;
 },
 {
+pos = (-26,0);
 ref = acutecomb;
 }
 );
@@ -3929,7 +4277,6 @@ unicode = 233;
 },
 {
 glyphname = ecircumflex;
-lastChange = "2023-11-01 07:38:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -3938,6 +4285,7 @@ shapes = (
 ref = e;
 },
 {
+pos = (6,0);
 ref = circumflexcomb;
 }
 );
@@ -3948,7 +4296,6 @@ unicode = 234;
 },
 {
 glyphname = edieresis;
-lastChange = "2023-11-01 07:38:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -3967,7 +4314,6 @@ unicode = 235;
 },
 {
 glyphname = egrave;
-lastChange = "2023-11-01 07:38:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -3976,6 +4322,7 @@ shapes = (
 ref = e;
 },
 {
+pos = (19,0);
 ref = gravecomb;
 }
 );
@@ -3986,9 +4333,18 @@ unicode = 232;
 },
 {
 glyphname = f;
-lastChange = "2023-09-16 06:44:10 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,750);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -4104,9 +4460,18 @@ unicode = 102;
 },
 {
 glyphname = g;
-lastChange = "2023-09-16 06:48:41 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,-200);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -4380,9 +4745,22 @@ unicode = 103;
 },
 {
 glyphname = h;
-lastChange = "2023-05-04 05:20:12 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,750);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -4437,54 +4815,15 @@ unicode = 104;
 },
 {
 glyphname = i;
-lastChange = "2023-05-04 05:20:16 +0000";
 layers = (
 {
 layerId = m01;
 shapes = (
 {
-closed = 1;
-nodes = (
-(350,606,o),
-(385,641,o),
-(385,686,cs),
-(385,730,o),
-(350,766,o),
-(305,766,cs),
-(262,766,o),
-(225,730,o),
-(225,686,cs),
-(225,641,o),
-(262,606,o),
-(305,606,cs)
-);
+ref = idotless;
 },
 {
-closed = 1;
-nodes = (
-(149,421,l),
-(382,421,l),
-(382,509,l),
-(149,509,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(284,509,l),
-(284,0,l),
-(382,0,l),
-(382,509,l)
-);
-},
-{
-closed = 1;
-nodes = (
-(95,0,l),
-(543,0,l),
-(543,88,l),
-(95,88,l)
-);
+ref = dotaccentcomb;
 }
 );
 width = 620;
@@ -4494,9 +4833,22 @@ unicode = 105;
 },
 {
 glyphname = idotless;
-lastChange = "2023-11-01 10:02:42 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (543,0);
+},
+{
+name = top;
+pos = (305,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4534,7 +4886,6 @@ unicode = 305;
 },
 {
 glyphname = iacute;
-lastChange = "2023-11-01 10:03:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -4543,6 +4894,7 @@ shapes = (
 ref = idotless;
 },
 {
+pos = (-31,0);
 ref = acutecomb;
 }
 );
@@ -4553,7 +4905,6 @@ unicode = 237;
 },
 {
 glyphname = icircumflex;
-lastChange = "2023-11-01 10:05:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -4562,6 +4913,7 @@ shapes = (
 ref = idotless;
 },
 {
+pos = (1,0);
 ref = circumflexcomb;
 }
 );
@@ -4572,7 +4924,6 @@ unicode = 238;
 },
 {
 glyphname = idieresis;
-lastChange = "2023-11-01 10:06:00 +0000";
 layers = (
 {
 layerId = m01;
@@ -4581,6 +4932,7 @@ shapes = (
 ref = idotless;
 },
 {
+pos = (-5,0);
 ref = dieresiscomb;
 }
 );
@@ -4591,7 +4943,6 @@ unicode = 239;
 },
 {
 glyphname = igrave;
-lastChange = "2023-11-01 10:06:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -4600,6 +4951,7 @@ shapes = (
 ref = idotless;
 },
 {
+pos = (14,0);
 ref = gravecomb;
 }
 );
@@ -4610,9 +4962,37 @@ unicode = 236;
 },
 {
 glyphname = j;
-lastChange = "2023-05-04 05:20:20 +0000";
 layers = (
 {
+layerId = m01;
+shapes = (
+{
+ref = jdotless;
+},
+{
+pos = (43,0);
+ref = dotaccentcomb;
+}
+);
+width = 620;
+}
+);
+unicode = 106;
+},
+{
+glyphname = jdotless;
+layers = (
+{
+anchors = (
+{
+name = bottom;
+pos = (310,-200);
+},
+{
+name = top;
+pos = (348,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4636,23 +5016,6 @@ nodes = (
 {
 closed = 1;
 nodes = (
-(393,606,o),
-(428,641,o),
-(428,686,cs),
-(428,730,o),
-(393,766,o),
-(348,766,cs),
-(305,766,o),
-(268,730,o),
-(268,686,cs),
-(268,641,o),
-(305,606,o),
-(348,606,cs)
-);
-},
-{
-closed = 1;
-nodes = (
 (465,-129,o),
 (458,-200,o),
 (307,-200,cs),
@@ -4669,13 +5032,22 @@ nodes = (
 width = 620;
 }
 );
-unicode = 106;
+unicode = 567;
 },
 {
 glyphname = k;
-lastChange = "2023-05-04 05:20:24 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,750);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -4706,9 +5078,26 @@ unicode = 107;
 },
 {
 glyphname = l;
-lastChange = "2023-05-03 11:41:10 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,750);
+},
+{
+name = topright;
+pos = (600,750);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4752,9 +5141,18 @@ unicode = 108;
 },
 {
 glyphname = m;
-lastChange = "2023-05-04 05:20:30 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4819,9 +5217,18 @@ unicode = 109;
 },
 {
 glyphname = n;
-lastChange = "2023-05-04 05:20:34 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4861,7 +5268,6 @@ unicode = 110;
 },
 {
 glyphname = ntilde;
-lastChange = "2023-11-01 11:29:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -4870,6 +5276,7 @@ shapes = (
 ref = n;
 },
 {
+pos = (10,0);
 ref = tildecomb;
 }
 );
@@ -4880,9 +5287,30 @@ unicode = 241;
 },
 {
 glyphname = o;
-lastChange = "2023-05-04 05:20:38 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,550);
+},
+{
+name = topright;
+pos = (600,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -4927,7 +5355,6 @@ unicode = 111;
 },
 {
 glyphname = oacute;
-lastChange = "2023-11-01 11:31:59 +0000";
 layers = (
 {
 layerId = m01;
@@ -4936,6 +5363,7 @@ shapes = (
 ref = o;
 },
 {
+pos = (-26,0);
 ref = acutecomb;
 }
 );
@@ -4946,7 +5374,6 @@ unicode = 243;
 },
 {
 glyphname = ocircumflex;
-lastChange = "2023-11-01 11:32:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -4955,6 +5382,7 @@ shapes = (
 ref = o;
 },
 {
+pos = (6,0);
 ref = circumflexcomb;
 }
 );
@@ -4965,7 +5393,6 @@ unicode = 244;
 },
 {
 glyphname = odieresis;
-lastChange = "2023-11-01 11:32:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -4984,7 +5411,6 @@ unicode = 246;
 },
 {
 glyphname = ograve;
-lastChange = "2023-11-01 11:32:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -4993,6 +5419,7 @@ shapes = (
 ref = o;
 },
 {
+pos = (19,0);
 ref = gravecomb;
 }
 );
@@ -5003,7 +5430,6 @@ unicode = 242;
 },
 {
 glyphname = oslash;
-lastChange = "2023-11-01 12:25:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -5052,7 +5478,6 @@ unicode = 248;
 },
 {
 glyphname = otilde;
-lastChange = "2023-11-01 11:37:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -5061,6 +5486,7 @@ shapes = (
 ref = o;
 },
 {
+pos = (10,0);
 ref = tildecomb;
 }
 );
@@ -5071,9 +5497,18 @@ unicode = 245;
 },
 {
 glyphname = oe;
-lastChange = "2023-11-05 06:23:28 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5234,9 +5669,18 @@ unicode = 339;
 },
 {
 glyphname = p;
-lastChange = "2023-05-04 05:20:41 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5301,9 +5745,18 @@ unicode = 112;
 },
 {
 glyphname = q;
-lastChange = "2023-05-04 05:20:45 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -5373,9 +5826,18 @@ unicode = 113;
 },
 {
 glyphname = r;
-lastChange = "2023-05-04 05:20:49 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -5428,9 +5890,18 @@ unicode = 114;
 },
 {
 glyphname = s;
-lastChange = "2023-05-02 03:42:17 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5478,7 +5949,6 @@ unicode = 115;
 },
 {
 glyphname = scaron;
-lastChange = "2023-11-02 00:33:06 +0000";
 layers = (
 {
 layerId = m01;
@@ -5487,9 +5957,8 @@ shapes = (
 ref = s;
 },
 {
-pos = (0,1394);
-ref = circumflexcomb;
-scale = (1,-1);
+pos = (6,0);
+ref = caroncomb;
 }
 );
 width = 620;
@@ -5499,7 +5968,6 @@ unicode = 353;
 },
 {
 glyphname = germandbls;
-lastChange = "2023-11-05 06:23:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -5670,9 +6138,26 @@ unicode = 223;
 },
 {
 glyphname = t;
-lastChange = "2023-09-16 06:45:12 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,550);
+},
+{
+name = topright;
+pos = (600,750);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5709,9 +6194,26 @@ unicode = 116;
 },
 {
 glyphname = u;
-lastChange = "2023-05-04 05:20:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = ogonek;
+pos = (558,10);
+},
+{
+name = top;
+pos = (310,550);
+},
+{
+name = topright;
+pos = (600,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5759,7 +6261,6 @@ unicode = 117;
 },
 {
 glyphname = uacute;
-lastChange = "2023-11-02 02:49:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -5768,6 +6269,7 @@ shapes = (
 ref = u;
 },
 {
+pos = (-26,0);
 ref = acutecomb;
 }
 );
@@ -5778,7 +6280,6 @@ unicode = 250;
 },
 {
 glyphname = ucircumflex;
-lastChange = "2023-11-02 02:49:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -5787,6 +6288,7 @@ shapes = (
 ref = u;
 },
 {
+pos = (6,0);
 ref = circumflexcomb;
 }
 );
@@ -5797,7 +6299,6 @@ unicode = 251;
 },
 {
 glyphname = udieresis;
-lastChange = "2023-11-02 04:26:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -5806,7 +6307,6 @@ shapes = (
 ref = u;
 },
 {
-pos = (-12,0);
 ref = dieresiscomb;
 }
 );
@@ -5817,7 +6317,6 @@ unicode = 252;
 },
 {
 glyphname = ugrave;
-lastChange = "2023-11-02 02:49:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -5826,6 +6325,7 @@ shapes = (
 ref = u;
 },
 {
+pos = (19,0);
 ref = gravecomb;
 }
 );
@@ -5836,9 +6336,18 @@ unicode = 249;
 },
 {
 glyphname = v;
-lastChange = "2023-05-04 05:21:03 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 name = Regular;
 shapes = (
@@ -5876,9 +6385,18 @@ unicode = 118;
 },
 {
 glyphname = w;
-lastChange = "2023-04-27 08:54:37 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5933,9 +6451,18 @@ unicode = 119;
 },
 {
 glyphname = x;
-lastChange = "2023-05-04 05:21:10 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -5986,7 +6513,6 @@ unicode = 120;
 },
 {
 glyphname = y;
-lastChange = "2023-05-04 05:21:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -6047,7 +6573,6 @@ unicode = 121;
 },
 {
 glyphname = yacute;
-lastChange = "2023-11-02 02:53:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -6066,7 +6591,6 @@ unicode = 253;
 },
 {
 glyphname = ydieresis;
-lastChange = "2023-11-02 04:26:11 +0000";
 layers = (
 {
 layerId = m01;
@@ -6086,9 +6610,22 @@ unicode = 255;
 },
 {
 glyphname = z;
-lastChange = "2023-04-27 12:56:59 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+pos = (310,0);
+},
+{
+name = center;
+pos = (310,275);
+},
+{
+name = top;
+pos = (310,550);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -6126,7 +6663,6 @@ unicode = 122;
 },
 {
 glyphname = zcaron;
-lastChange = "2023-11-02 02:55:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -6135,9 +6671,8 @@ shapes = (
 ref = z;
 },
 {
-pos = (14,1394);
-ref = circumflexcomb;
-scale = (1,-1);
+pos = (6,0);
+ref = caroncomb;
 }
 );
 width = 620;
@@ -6147,7 +6682,6 @@ unicode = 382;
 },
 {
 glyphname = zero;
-lastChange = "2023-05-04 05:22:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -6203,7 +6737,6 @@ unicode = 48;
 },
 {
 glyphname = one;
-lastChange = "2023-05-04 05:21:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -6248,7 +6781,6 @@ unicode = 49;
 },
 {
 glyphname = two;
-lastChange = "2023-05-04 05:21:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -6298,7 +6830,6 @@ unicode = 50;
 },
 {
 glyphname = three;
-lastChange = "2023-04-30 14:48:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -6361,7 +6892,6 @@ unicode = 51;
 },
 {
 glyphname = four;
-lastChange = "2023-05-04 05:21:53 +0000";
 layers = (
 {
 layerId = m01;
@@ -6406,7 +6936,6 @@ unicode = 52;
 },
 {
 glyphname = five;
-lastChange = "2023-05-04 05:21:56 +0000";
 layers = (
 {
 layerId = m01;
@@ -6469,7 +6998,6 @@ unicode = 53;
 },
 {
 glyphname = six;
-lastChange = "2023-05-04 05:22:01 +0000";
 layers = (
 {
 layerId = m01;
@@ -6524,7 +7052,6 @@ unicode = 54;
 },
 {
 glyphname = seven;
-lastChange = "2023-04-30 04:40:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -6577,7 +7104,6 @@ unicode = 55;
 },
 {
 glyphname = eight;
-lastChange = "2023-05-04 05:22:06 +0000";
 layers = (
 {
 layerId = m01;
@@ -6653,7 +7179,6 @@ unicode = 56;
 },
 {
 glyphname = nine;
-lastChange = "2023-05-04 05:22:10 +0000";
 layers = (
 {
 layerId = m01;
@@ -6707,7 +7232,6 @@ unicode = 57;
 },
 {
 glyphname = space;
-lastChange = "2023-09-14 07:04:18 +0000";
 layers = (
 {
 layerId = m01;
@@ -6718,7 +7242,6 @@ unicode = 32;
 },
 {
 glyphname = hyphen_greater;
-lastChange = "2023-09-26 03:41:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -6759,7 +7282,6 @@ width = 620;
 },
 {
 glyphname = bracketleft_bar;
-lastChange = "2023-09-26 03:41:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -6807,7 +7329,6 @@ width = 620;
 },
 {
 glyphname = period_equal;
-lastChange = "2023-09-29 06:57:57 +0000";
 layers = (
 {
 layerId = m01;
@@ -6897,7 +7418,6 @@ width = 620;
 },
 {
 glyphname = colon_colon;
-lastChange = "2023-09-26 03:42:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -6977,7 +7497,6 @@ width = 620;
 },
 {
 glyphname = colon_colon_colon;
-lastChange = "2023-09-26 03:42:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -7091,7 +7610,6 @@ width = 620;
 },
 {
 glyphname = colon_equal;
-lastChange = "2023-09-26 03:42:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -7155,7 +7673,6 @@ width = 620;
 },
 {
 glyphname = colon_greater_colon;
-lastChange = "2023-09-26 03:43:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -7255,7 +7772,6 @@ width = 620;
 },
 {
 glyphname = colon_less_colon;
-lastChange = "2023-09-26 03:43:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -7355,7 +7871,6 @@ width = 620;
 },
 {
 glyphname = exclam_equal;
-lastChange = "2023-09-29 06:57:45 +0000";
 layers = (
 {
 layerId = m01;
@@ -7471,7 +7986,6 @@ width = 620;
 },
 {
 glyphname = exclam_equal_equal;
-lastChange = "2023-09-29 06:57:30 +0000";
 layers = (
 {
 layerId = m01;
@@ -7623,7 +8137,6 @@ width = 620;
 },
 {
 glyphname = question_question;
-lastChange = "2023-09-29 06:57:11 +0000";
 layers = (
 {
 layerId = m01;
@@ -7847,7 +8360,6 @@ width = 620;
 },
 {
 glyphname = asterisk_asterisk;
-lastChange = "2023-09-26 03:13:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -7949,7 +8461,6 @@ width = 620;
 },
 {
 glyphname = asterisk_asterisk_asterisk;
-lastChange = "2023-09-26 00:08:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -8096,7 +8607,6 @@ width = 620;
 },
 {
 glyphname = asterisk_greater;
-lastChange = "2023-09-26 03:44:19 +0000";
 layers = (
 {
 layerId = m01;
@@ -8173,7 +8683,6 @@ width = 620;
 },
 {
 glyphname = numbersign_equal;
-lastChange = "2023-09-26 03:54:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -8239,7 +8748,6 @@ width = 620;
 },
 {
 glyphname = slash_slash;
-lastChange = "2023-09-26 03:55:01 +0000";
 layers = (
 {
 layerId = m01;
@@ -8273,7 +8781,6 @@ width = 620;
 },
 {
 glyphname = slash_slash_slash;
-lastChange = "2023-09-26 03:55:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -8318,7 +8825,6 @@ width = 620;
 },
 {
 glyphname = period;
-lastChange = "2023-09-29 06:56:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -8373,7 +8879,6 @@ unicode = 46;
 },
 {
 glyphname = comma;
-lastChange = "2023-09-29 06:56:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -8447,7 +8952,6 @@ unicode = 44;
 },
 {
 glyphname = colon;
-lastChange = "2023-05-14 05:55:00 +0000";
 layers = (
 {
 layerId = m01;
@@ -8494,7 +8998,6 @@ unicode = 58;
 },
 {
 glyphname = semicolon;
-lastChange = "2023-09-29 06:56:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -8602,7 +9105,6 @@ unicode = 59;
 },
 {
 glyphname = exclam;
-lastChange = "2023-09-29 06:56:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -8683,7 +9185,6 @@ unicode = 33;
 },
 {
 glyphname = exclamdown;
-lastChange = "2023-11-05 12:57:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -8726,7 +9227,6 @@ unicode = 161;
 },
 {
 glyphname = question;
-lastChange = "2023-09-29 06:55:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -8842,7 +9342,6 @@ unicode = 63;
 },
 {
 glyphname = questiondown;
-lastChange = "2023-11-05 12:58:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -8899,7 +9398,6 @@ unicode = 191;
 },
 {
 glyphname = asterisk;
-lastChange = "2023-07-18 08:15:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -8957,7 +9455,6 @@ unicode = 42;
 },
 {
 glyphname = numbersign;
-lastChange = "2023-05-02 06:32:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -9006,7 +9503,6 @@ unicode = 35;
 },
 {
 glyphname = slash;
-lastChange = "2023-05-03 07:39:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -9030,7 +9526,6 @@ unicode = 47;
 },
 {
 glyphname = backslash;
-lastChange = "2023-05-03 07:40:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -9054,7 +9549,6 @@ unicode = 92;
 },
 {
 glyphname = period.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9064,7 +9558,6 @@ width = 620;
 },
 {
 glyphname = colon.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9074,7 +9567,6 @@ width = 620;
 },
 {
 glyphname = exclam.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9084,7 +9576,6 @@ width = 620;
 },
 {
 glyphname = question.spacer;
-lastChange = "2023-09-29 06:52:06 +0000";
 layers = (
 {
 layerId = m01;
@@ -9094,7 +9585,6 @@ width = 620;
 },
 {
 glyphname = asterisk.spacer;
-lastChange = "2023-09-26 03:07:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -9104,7 +9594,6 @@ width = 620;
 },
 {
 glyphname = numbersign.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9114,7 +9603,6 @@ width = 620;
 },
 {
 glyphname = slash.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9124,7 +9612,6 @@ width = 620;
 },
 {
 glyphname = hyphen;
-lastChange = "2023-05-04 01:11:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -9146,7 +9633,6 @@ unicode = 45;
 },
 {
 glyphname = underscore;
-lastChange = "2023-05-04 01:07:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -9168,7 +9654,6 @@ unicode = 95;
 },
 {
 glyphname = hyphen.spacer;
-lastChange = "2023-09-29 06:51:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -9178,7 +9663,6 @@ width = 620;
 },
 {
 glyphname = parenleft;
-lastChange = "2023-09-29 06:55:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -9233,7 +9717,6 @@ unicode = 40;
 },
 {
 glyphname = parenright;
-lastChange = "2023-09-29 06:55:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -9288,7 +9771,6 @@ unicode = 41;
 },
 {
 glyphname = braceleft;
-lastChange = "2023-09-29 06:54:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -9425,7 +9907,6 @@ unicode = 123;
 },
 {
 glyphname = braceright;
-lastChange = "2023-09-29 06:54:42 +0000";
 layers = (
 {
 layerId = m01;
@@ -9562,7 +10043,6 @@ unicode = 125;
 },
 {
 glyphname = bracketleft;
-lastChange = "2023-09-29 06:54:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -9637,7 +10117,6 @@ unicode = 91;
 },
 {
 glyphname = bracketright;
-lastChange = "2023-09-29 06:54:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -9712,7 +10191,6 @@ unicode = 93;
 },
 {
 glyphname = bracketleft.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -9722,7 +10200,6 @@ width = 620;
 },
 {
 glyphname = quotedblleft;
-lastChange = "2023-05-04 05:25:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -9787,7 +10264,6 @@ unicode = 8220;
 },
 {
 glyphname = quotedblright;
-lastChange = "2023-05-04 05:25:44 +0000";
 layers = (
 {
 layerId = m01;
@@ -9852,7 +10328,6 @@ unicode = 8221;
 },
 {
 glyphname = quoteleft;
-lastChange = "2023-05-04 05:25:35 +0000";
 layers = (
 {
 layerId = m01;
@@ -9891,7 +10366,6 @@ unicode = 8216;
 },
 {
 glyphname = quoteright;
-lastChange = "2023-05-04 05:25:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -9930,7 +10404,6 @@ unicode = 8217;
 },
 {
 glyphname = quotedbl;
-lastChange = "2023-05-04 05:24:44 +0000";
 layers = (
 {
 layerId = m01;
@@ -9961,7 +10434,6 @@ unicode = 34;
 },
 {
 glyphname = quotesingle;
-lastChange = "2023-05-01 14:01:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -9983,7 +10455,6 @@ unicode = 39;
 },
 {
 glyphname = ampersand_ampersand;
-lastChange = "2023-09-26 03:56:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -10106,7 +10577,6 @@ width = 620;
 },
 {
 glyphname = bar_bracketright;
-lastChange = "2023-09-26 03:56:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -10154,7 +10624,6 @@ width = 620;
 },
 {
 glyphname = bar_bar;
-lastChange = "2023-09-26 03:56:49 +0000";
 layers = (
 {
 layerId = m01;
@@ -10184,7 +10653,6 @@ width = 620;
 },
 {
 glyphname = bar_bar_bar_greater;
-lastChange = "2023-09-26 03:57:10 +0000";
 layers = (
 {
 layerId = m01;
@@ -10243,7 +10711,6 @@ width = 620;
 },
 {
 glyphname = bar_bar_greater;
-lastChange = "2023-09-26 03:57:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -10293,7 +10760,6 @@ width = 620;
 },
 {
 glyphname = bar_greater;
-lastChange = "2023-09-26 03:57:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -10334,7 +10800,6 @@ width = 620;
 },
 {
 glyphname = dollar_greater;
-lastChange = "2023-09-26 03:58:01 +0000";
 layers = (
 {
 layerId = m01;
@@ -10425,7 +10890,6 @@ width = 620;
 },
 {
 glyphname = plus_greater;
-lastChange = "2023-09-26 03:58:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -10475,7 +10939,6 @@ width = 620;
 },
 {
 glyphname = equal_colon_equal;
-lastChange = "2023-09-26 03:59:01 +0000";
 layers = (
 {
 layerId = m01;
@@ -10557,7 +11020,6 @@ width = 620;
 },
 {
 glyphname = equal_exclam_equal;
-lastChange = "2023-09-29 06:54:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -10709,7 +11171,6 @@ width = 620;
 },
 {
 glyphname = equal_equal;
-lastChange = "2023-09-26 04:07:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -10757,7 +11218,6 @@ width = 620;
 },
 {
 glyphname = equal_equal_equal;
-lastChange = "2023-09-26 04:07:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -10823,7 +11283,6 @@ width = 620;
 },
 {
 glyphname = equal_greater;
-lastChange = "2023-09-26 04:07:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -10873,7 +11332,6 @@ width = 620;
 },
 {
 glyphname = equal_greater_equal;
-lastChange = "2023-09-26 04:08:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -10941,7 +11399,6 @@ width = 620;
 },
 {
 glyphname = equal_greater_greater;
-lastChange = "2023-09-26 04:11:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -11011,7 +11468,6 @@ width = 620;
 },
 {
 glyphname = equal_less_equal;
-lastChange = "2023-09-26 04:11:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -11079,7 +11535,6 @@ width = 620;
 },
 {
 glyphname = equal_less_less;
-lastChange = "2023-09-26 04:12:04 +0000";
 layers = (
 {
 layerId = m01;
@@ -11149,7 +11604,6 @@ width = 620;
 },
 {
 glyphname = greater_equal_greater;
-lastChange = "2023-09-26 04:12:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -11219,7 +11673,6 @@ width = 620;
 },
 {
 glyphname = greater_greater;
-lastChange = "2023-09-26 04:12:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -11271,7 +11724,6 @@ width = 620;
 },
 {
 glyphname = greater_greater_greater;
-lastChange = "2023-09-26 04:12:42 +0000";
 layers = (
 {
 layerId = m01;
@@ -11343,7 +11795,6 @@ width = 620;
 },
 {
 glyphname = less_hyphen;
-lastChange = "2023-09-26 04:13:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -11384,7 +11835,6 @@ width = 620;
 },
 {
 glyphname = less_asterisk;
-lastChange = "2023-09-26 04:13:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -11461,7 +11911,6 @@ width = 620;
 },
 {
 glyphname = less_asterisk_greater;
-lastChange = "2023-09-26 04:13:26 +0000";
 layers = (
 {
 layerId = m01;
@@ -11558,7 +12007,6 @@ width = 620;
 },
 {
 glyphname = less_bar;
-lastChange = "2023-09-26 04:13:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -11599,7 +12047,6 @@ width = 620;
 },
 {
 glyphname = less_bar_bar;
-lastChange = "2023-09-26 04:14:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -11649,7 +12096,6 @@ width = 620;
 },
 {
 glyphname = less_bar_bar_bar;
-lastChange = "2023-09-26 04:14:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -11708,7 +12154,6 @@ width = 620;
 },
 {
 glyphname = less_bar_greater;
-lastChange = "2023-09-26 04:14:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -11769,7 +12214,6 @@ width = 620;
 },
 {
 glyphname = less_dollar;
-lastChange = "2023-09-26 04:14:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -11860,7 +12304,6 @@ width = 620;
 },
 {
 glyphname = less_dollar_greater;
-lastChange = "2023-09-26 04:14:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -11971,7 +12414,6 @@ width = 620;
 },
 {
 glyphname = less_plus;
-lastChange = "2023-09-26 04:15:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -12021,7 +12463,6 @@ width = 620;
 },
 {
 glyphname = less_plus_greater;
-lastChange = "2023-09-26 04:15:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -12091,7 +12532,6 @@ width = 620;
 },
 {
 glyphname = less_equal_greater;
-lastChange = "2023-09-26 04:15:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -12161,7 +12601,6 @@ width = 620;
 },
 {
 glyphname = less_equal_less;
-lastChange = "2023-09-26 04:15:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -12231,7 +12670,6 @@ width = 620;
 },
 {
 glyphname = less_greater;
-lastChange = "2023-09-26 04:16:04 +0000";
 layers = (
 {
 layerId = m01;
@@ -12283,7 +12721,6 @@ width = 620;
 },
 {
 glyphname = less_less;
-lastChange = "2023-09-26 04:16:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -12335,7 +12772,6 @@ width = 620;
 },
 {
 glyphname = less_less_less;
-lastChange = "2023-09-26 04:16:25 +0000";
 layers = (
 {
 layerId = m01;
@@ -12407,7 +12843,6 @@ width = 620;
 },
 {
 glyphname = percent_percent;
-lastChange = "2023-09-26 04:16:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -12577,7 +13012,6 @@ width = 620;
 },
 {
 glyphname = at;
-lastChange = "2023-05-04 05:24:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -12667,7 +13101,6 @@ unicode = 64;
 },
 {
 glyphname = ampersand;
-lastChange = "2023-05-04 05:24:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -12736,7 +13169,6 @@ unicode = 38;
 },
 {
 glyphname = bar;
-lastChange = "2023-05-01 11:35:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -12758,7 +13190,6 @@ unicode = 124;
 },
 {
 glyphname = ampersand.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -12768,7 +13199,6 @@ width = 620;
 },
 {
 glyphname = bar.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -12778,7 +13208,6 @@ width = 620;
 },
 {
 glyphname = dollar;
-lastChange = "2023-05-04 05:24:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -12850,7 +13279,6 @@ unicode = 36;
 },
 {
 glyphname = dollar.spacer;
-lastChange = "2023-10-29 06:55:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -12860,7 +13288,6 @@ width = 620;
 },
 {
 glyphname = plus;
-lastChange = "2023-05-04 05:24:02 +0000";
 layers = (
 {
 layerId = m01;
@@ -12891,7 +13318,6 @@ unicode = 43;
 },
 {
 glyphname = minus;
-lastChange = "2023-05-03 11:30:46 +0000";
 layers = (
 {
 layerId = m01;
@@ -12913,7 +13339,6 @@ unicode = 8722;
 },
 {
 glyphname = equal;
-lastChange = "2023-05-04 01:14:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -12944,7 +13369,6 @@ unicode = 61;
 },
 {
 glyphname = greater;
-lastChange = "2023-05-04 05:23:55 +0000";
 layers = (
 {
 layerId = m01;
@@ -12977,7 +13401,6 @@ unicode = 62;
 },
 {
 glyphname = less;
-lastChange = "2023-05-04 01:13:44 +0000";
 layers = (
 {
 layerId = m01;
@@ -13010,7 +13433,6 @@ unicode = 60;
 },
 {
 glyphname = asciitilde;
-lastChange = "2023-09-16 06:39:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -13076,7 +13498,6 @@ unicode = 126;
 },
 {
 glyphname = asciicircum;
-lastChange = "2023-05-02 07:11:35 +0000";
 layers = (
 {
 layerId = m01;
@@ -13109,7 +13530,6 @@ unicode = 94;
 },
 {
 glyphname = percent;
-lastChange = "2023-05-04 01:28:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -13201,7 +13621,6 @@ unicode = 37;
 },
 {
 glyphname = plus.spacer;
-lastChange = "2023-09-26 12:14:26 +0000";
 layers = (
 {
 layerId = m01;
@@ -13211,7 +13630,6 @@ width = 620;
 },
 {
 glyphname = equal.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -13221,7 +13639,6 @@ width = 620;
 },
 {
 glyphname = greater.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -13231,7 +13648,6 @@ width = 620;
 },
 {
 glyphname = less.spacer;
-lastChange = "2023-09-26 12:39:45 +0000";
 layers = (
 {
 layerId = m01;
@@ -13241,7 +13657,6 @@ width = 620;
 },
 {
 glyphname = percent.spacer;
-lastChange = "2023-11-02 03:27:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -13251,7 +13666,6 @@ width = 620;
 },
 {
 glyphname = boxDoubleDownAndHorizontal;
-lastChange = "2023-09-13 03:17:42 +0000";
 layers = (
 {
 layerId = m01;
@@ -13309,7 +13723,6 @@ unicode = 9574;
 },
 {
 glyphname = boxDoubleDownAndLeft;
-lastChange = "2023-09-12 05:48:32 +0000";
 layers = (
 {
 layerId = m01;
@@ -13358,7 +13771,6 @@ unicode = 9559;
 },
 {
 glyphname = boxDoubleDownAndRight;
-lastChange = "2023-09-12 05:49:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -13407,7 +13819,6 @@ unicode = 9556;
 },
 {
 glyphname = boxDoubleHorizontal;
-lastChange = "2023-09-12 05:43:48 +0000";
 layers = (
 {
 layerId = m01;
@@ -13438,7 +13849,6 @@ unicode = 9552;
 },
 {
 glyphname = boxDoubleUpAndHorizontal;
-lastChange = "2023-09-13 03:17:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -13496,7 +13906,6 @@ unicode = 9577;
 },
 {
 glyphname = boxDoubleUpAndLeft;
-lastChange = "2023-09-12 05:50:33 +0000";
 layers = (
 {
 layerId = m01;
@@ -13545,7 +13954,6 @@ unicode = 9565;
 },
 {
 glyphname = boxDoubleUpAndRight;
-lastChange = "2023-09-12 05:50:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -13594,7 +14002,6 @@ unicode = 9562;
 },
 {
 glyphname = boxDoubleVertical;
-lastChange = "2023-09-12 05:45:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -13625,7 +14032,6 @@ unicode = 9553;
 },
 {
 glyphname = boxDoubleVerticalAndHorizontal;
-lastChange = "2023-09-13 03:17:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -13710,7 +14116,6 @@ unicode = 9580;
 },
 {
 glyphname = boxDoubleVerticalAndLeft;
-lastChange = "2023-09-13 02:14:59 +0000";
 layers = (
 {
 layerId = m01;
@@ -13768,7 +14173,6 @@ unicode = 9571;
 },
 {
 glyphname = boxDoubleVerticalAndRight;
-lastChange = "2023-09-13 02:15:22 +0000";
 layers = (
 {
 layerId = m01;
@@ -13826,7 +14230,6 @@ unicode = 9568;
 },
 {
 glyphname = boxDownDoubleAndHorizontalSingle;
-lastChange = "2023-09-13 02:15:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -13866,7 +14269,6 @@ unicode = 9573;
 },
 {
 glyphname = boxDownDoubleAndLeftSingle;
-lastChange = "2023-09-12 05:52:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -13906,7 +14308,6 @@ unicode = 9558;
 },
 {
 glyphname = boxDownDoubleAndRightSingle;
-lastChange = "2023-09-12 05:52:35 +0000";
 layers = (
 {
 layerId = m01;
@@ -13946,7 +14347,6 @@ unicode = 9555;
 },
 {
 glyphname = boxDownHeavyAndHorizontalLight;
-lastChange = "2023-09-12 04:50:55 +0000";
 layers = (
 {
 layerId = m01;
@@ -13977,7 +14377,6 @@ unicode = 9520;
 },
 {
 glyphname = boxDownHeavyAndLeftLight;
-lastChange = "2023-09-12 04:42:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -14008,7 +14407,6 @@ unicode = 9490;
 },
 {
 glyphname = boxDownHeavyAndLeftUpLight;
-lastChange = "2023-09-12 04:45:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -14057,7 +14455,6 @@ unicode = 9511;
 },
 {
 glyphname = boxDownHeavyAndRightLight;
-lastChange = "2023-09-12 04:39:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -14088,7 +14485,6 @@ unicode = 9486;
 },
 {
 glyphname = boxDownHeavyAndRightUpLight;
-lastChange = "2023-09-12 04:42:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -14128,7 +14524,6 @@ unicode = 9503;
 },
 {
 glyphname = boxDownHeavyAndUpHorizontalLight;
-lastChange = "2023-09-12 04:57:06 +0000";
 layers = (
 {
 layerId = m01;
@@ -14168,7 +14563,6 @@ unicode = 9537;
 },
 {
 glyphname = boxDownLightAndHorizontalHeavy;
-lastChange = "2023-09-12 04:45:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -14199,7 +14593,6 @@ unicode = 9519;
 },
 {
 glyphname = boxDownLightAndLeftHeavy;
-lastChange = "2023-09-12 04:42:53 +0000";
 layers = (
 {
 layerId = m01;
@@ -14230,7 +14623,6 @@ unicode = 9489;
 },
 {
 glyphname = boxDownLightAndLeftUpHeavy;
-lastChange = "2023-09-12 04:46:07 +0000";
 layers = (
 {
 layerId = m01;
@@ -14270,7 +14662,6 @@ unicode = 9513;
 },
 {
 glyphname = boxDownLightAndRightHeavy;
-lastChange = "2023-09-12 04:39:23 +0000";
 layers = (
 {
 layerId = m01;
@@ -14301,7 +14692,6 @@ unicode = 9485;
 },
 {
 glyphname = boxDownLightAndRightUpHeavy;
-lastChange = "2023-09-12 04:46:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -14341,7 +14731,6 @@ unicode = 9505;
 },
 {
 glyphname = boxDownLightAndUpHorizontalHeavy;
-lastChange = "2023-09-12 05:29:55 +0000";
 layers = (
 {
 layerId = m01;
@@ -14381,7 +14770,6 @@ unicode = 9543;
 },
 {
 glyphname = boxDownSingleAndHorizontalDouble;
-lastChange = "2023-09-13 03:17:52 +0000";
 layers = (
 {
 layerId = m01;
@@ -14421,7 +14809,6 @@ unicode = 9572;
 },
 {
 glyphname = boxDownSingleAndLeftDouble;
-lastChange = "2023-09-13 01:58:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -14461,7 +14848,6 @@ unicode = 9557;
 },
 {
 glyphname = boxDownSingleAndRightDouble;
-lastChange = "2023-09-13 01:59:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -14501,7 +14887,6 @@ unicode = 9554;
 },
 {
 glyphname = boxHeavyDoubleDashHorizontal;
-lastChange = "2023-09-12 05:36:56 +0000";
 layers = (
 {
 layerId = m01;
@@ -14532,7 +14917,6 @@ unicode = 9549;
 },
 {
 glyphname = boxHeavyDoubleDashVertical;
-lastChange = "2023-09-13 06:15:29 +0000";
 layers = (
 {
 layerId = m01;
@@ -14563,7 +14947,6 @@ unicode = 9551;
 },
 {
 glyphname = boxHeavyDown;
-lastChange = "2023-09-13 03:30:22 +0000";
 layers = (
 {
 layerId = m01;
@@ -14585,7 +14968,6 @@ unicode = 9595;
 },
 {
 glyphname = boxHeavyDownAndHorizontal;
-lastChange = "2023-09-12 04:51:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -14616,7 +14998,6 @@ unicode = 9523;
 },
 {
 glyphname = boxHeavyDownAndLeft;
-lastChange = "2023-09-12 04:43:18 +0000";
 layers = (
 {
 layerId = m01;
@@ -14647,7 +15028,6 @@ unicode = 9491;
 },
 {
 glyphname = boxHeavyDownAndRight;
-lastChange = "2023-09-12 04:39:27 +0000";
 layers = (
 {
 layerId = m01;
@@ -14678,7 +15058,6 @@ unicode = 9487;
 },
 {
 glyphname = boxHeavyHorizontal;
-lastChange = "2023-09-12 04:39:32 +0000";
 layers = (
 {
 layerId = m01;
@@ -14700,7 +15079,6 @@ unicode = 9473;
 },
 {
 glyphname = boxHeavyLeft;
-lastChange = "2023-09-13 03:31:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -14722,7 +15100,6 @@ unicode = 9592;
 },
 {
 glyphname = boxHeavyLeftAndLightRight;
-lastChange = "2023-09-13 03:32:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -14753,7 +15130,6 @@ unicode = 9598;
 },
 {
 glyphname = boxHeavyQuadrupleDashHorizontal;
-lastChange = "2023-09-13 06:14:10 +0000";
 layers = (
 {
 layerId = m01;
@@ -14802,7 +15178,6 @@ unicode = 9481;
 },
 {
 glyphname = boxHeavyQuadrupleDashVertical;
-lastChange = "2023-09-12 04:39:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -14851,7 +15226,6 @@ unicode = 9483;
 },
 {
 glyphname = boxHeavyRight;
-lastChange = "2023-09-13 03:32:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -14873,7 +15247,6 @@ unicode = 9594;
 },
 {
 glyphname = boxHeavyTripleDashHorizontal;
-lastChange = "2023-09-12 05:35:07 +0000";
 layers = (
 {
 layerId = m01;
@@ -14913,7 +15286,6 @@ unicode = 9477;
 },
 {
 glyphname = boxHeavyTripleDashVertical;
-lastChange = "2023-09-12 04:40:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -14953,7 +15325,6 @@ unicode = 9479;
 },
 {
 glyphname = boxHeavyUp;
-lastChange = "2023-09-13 03:51:11 +0000";
 layers = (
 {
 layerId = m01;
@@ -14975,7 +15346,6 @@ unicode = 9593;
 },
 {
 glyphname = boxHeavyUpAndHorizontal;
-lastChange = "2023-09-12 04:51:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -15006,7 +15376,6 @@ unicode = 9531;
 },
 {
 glyphname = boxHeavyUpAndLeft;
-lastChange = "2023-09-12 04:43:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -15037,7 +15406,6 @@ unicode = 9499;
 },
 {
 glyphname = boxHeavyUpAndLightDown;
-lastChange = "2023-09-13 03:51:38 +0000";
 layers = (
 {
 layerId = m01;
@@ -15068,7 +15436,6 @@ unicode = 9599;
 },
 {
 glyphname = boxHeavyUpAndRight;
-lastChange = "2023-09-12 04:43:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -15099,7 +15466,6 @@ unicode = 9495;
 },
 {
 glyphname = boxHeavyVertical;
-lastChange = "2023-09-13 03:30:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -15121,7 +15487,6 @@ unicode = 9475;
 },
 {
 glyphname = boxHeavyVerticalAndHorizontal;
-lastChange = "2023-09-12 05:30:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -15161,7 +15526,6 @@ unicode = 9547;
 },
 {
 glyphname = boxHeavyVerticalAndLeft;
-lastChange = "2023-09-12 04:46:26 +0000";
 layers = (
 {
 layerId = m01;
@@ -15192,7 +15556,6 @@ unicode = 9515;
 },
 {
 glyphname = boxHeavyVerticalAndRight;
-lastChange = "2023-09-12 04:46:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -15223,7 +15586,6 @@ unicode = 9507;
 },
 {
 glyphname = boxLeftDownHeavyAndRightUpLight;
-lastChange = "2023-09-12 04:51:22 +0000";
 layers = (
 {
 layerId = m01;
@@ -15254,7 +15616,6 @@ unicode = 9524;
 },
 {
 glyphname = boxLeftHeavyAndRightDownLight;
-lastChange = "2023-09-12 04:46:50 +0000";
 layers = (
 {
 layerId = m01;
@@ -15294,7 +15655,6 @@ unicode = 9517;
 },
 {
 glyphname = boxLeftHeavyAndRightUpLight;
-lastChange = "2023-09-12 04:51:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -15334,7 +15694,6 @@ unicode = 9525;
 },
 {
 glyphname = boxLeftHeavyAndRightVerticalLight;
-lastChange = "2023-09-12 04:51:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -15374,7 +15733,6 @@ unicode = 9533;
 },
 {
 glyphname = boxLeftLightAndRightDownHeavy;
-lastChange = "2023-09-12 04:51:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -15414,7 +15772,6 @@ unicode = 9522;
 },
 {
 glyphname = boxLeftLightAndRightUpHeavy;
-lastChange = "2023-09-12 04:51:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -15454,7 +15811,6 @@ unicode = 9530;
 },
 {
 glyphname = boxLeftLightAndRightVerticalHeavy;
-lastChange = "2023-09-12 05:30:21 +0000";
 layers = (
 {
 layerId = m01;
@@ -15494,7 +15850,6 @@ unicode = 9546;
 },
 {
 glyphname = boxLeftUpHeavyAndRightDownLight;
-lastChange = "2023-09-12 05:30:33 +0000";
 layers = (
 {
 layerId = m01;
@@ -15543,7 +15898,6 @@ unicode = 9539;
 },
 {
 glyphname = boxLightArcDownAndLeft;
-lastChange = "2023-09-13 03:15:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -15573,7 +15927,6 @@ unicode = 9582;
 },
 {
 glyphname = boxLightArcDownAndRight;
-lastChange = "2023-09-13 03:16:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -15603,7 +15956,6 @@ unicode = 9581;
 },
 {
 glyphname = boxLightArcUpAndLeft;
-lastChange = "2023-09-13 03:17:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -15633,7 +15985,6 @@ unicode = 9583;
 },
 {
 glyphname = boxLightArcUpAndRight;
-lastChange = "2023-09-13 03:28:41 +0000";
 layers = (
 {
 layerId = m01;
@@ -15663,7 +16014,6 @@ unicode = 9584;
 },
 {
 glyphname = boxLightDiagonalCross;
-lastChange = "2023-09-13 05:37:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -15694,7 +16044,6 @@ unicode = 9587;
 },
 {
 glyphname = boxLightDiagonalUpperLeftToLowerRight;
-lastChange = "2023-09-13 05:37:19 +0000";
 layers = (
 {
 layerId = m01;
@@ -15716,7 +16065,6 @@ unicode = 9586;
 },
 {
 glyphname = boxLightDiagonalUpperRightToLowerLeft;
-lastChange = "2023-09-13 05:37:29 +0000";
 layers = (
 {
 layerId = m01;
@@ -15738,7 +16086,6 @@ unicode = 9585;
 },
 {
 glyphname = boxLightDoubleDashHorizontal;
-lastChange = "2023-09-12 05:34:44 +0000";
 layers = (
 {
 layerId = m01;
@@ -15769,7 +16116,6 @@ unicode = 9548;
 },
 {
 glyphname = boxLightDoubleDashVertical;
-lastChange = "2023-09-12 05:40:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -15800,7 +16146,6 @@ unicode = 9550;
 },
 {
 glyphname = boxLightDown;
-lastChange = "2023-09-13 03:58:19 +0000";
 layers = (
 {
 layerId = m01;
@@ -15822,7 +16167,6 @@ unicode = 9591;
 },
 {
 glyphname = boxLightDownAndHorizontal;
-lastChange = "2023-09-12 04:47:07 +0000";
 layers = (
 {
 layerId = m01;
@@ -15853,7 +16197,6 @@ unicode = 9516;
 },
 {
 glyphname = boxLightDownAndLeft;
-lastChange = "2023-09-12 04:43:59 +0000";
 layers = (
 {
 layerId = m01;
@@ -15884,7 +16227,6 @@ unicode = 9488;
 },
 {
 glyphname = boxLightDownAndRight;
-lastChange = "2023-09-12 04:40:35 +0000";
 layers = (
 {
 layerId = m01;
@@ -15915,7 +16257,6 @@ unicode = 9484;
 },
 {
 glyphname = boxLightHorizontal;
-lastChange = "2023-09-12 04:40:32 +0000";
 layers = (
 {
 layerId = m01;
@@ -15937,7 +16278,6 @@ unicode = 9472;
 },
 {
 glyphname = boxLightLeft;
-lastChange = "2023-09-13 03:57:36 +0000";
 layers = (
 {
 layerId = m01;
@@ -15959,7 +16299,6 @@ unicode = 9588;
 },
 {
 glyphname = boxLightLeftAndHeavyRight;
-lastChange = "2023-09-13 03:57:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -15990,7 +16329,6 @@ unicode = 9596;
 },
 {
 glyphname = boxLightQuadrupleDashHorizontal;
-lastChange = "2023-09-12 05:35:34 +0000";
 layers = (
 {
 layerId = m01;
@@ -16039,7 +16377,6 @@ unicode = 9480;
 },
 {
 glyphname = boxLightQuadrupleDashVertical;
-lastChange = "2023-09-12 04:40:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -16088,7 +16425,6 @@ unicode = 9482;
 },
 {
 glyphname = boxLightRight;
-lastChange = "2023-09-13 03:57:46 +0000";
 layers = (
 {
 layerId = m01;
@@ -16110,7 +16446,6 @@ unicode = 9590;
 },
 {
 glyphname = boxLightTripleDashHorizontal;
-lastChange = "2023-09-12 05:35:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -16150,7 +16485,6 @@ unicode = 9476;
 },
 {
 glyphname = boxLightTripleDashVertical;
-lastChange = "2023-09-12 04:41:19 +0000";
 layers = (
 {
 layerId = m01;
@@ -16190,7 +16524,6 @@ unicode = 9478;
 },
 {
 glyphname = boxLightUp;
-lastChange = "2023-09-13 03:54:25 +0000";
 layers = (
 {
 layerId = m01;
@@ -16212,7 +16545,6 @@ unicode = 9589;
 },
 {
 glyphname = boxLightUpAndHeavyDown;
-lastChange = "2023-09-13 03:53:11 +0000";
 layers = (
 {
 layerId = m01;
@@ -16243,7 +16575,6 @@ unicode = 9597;
 },
 {
 glyphname = boxLightUpAndLeft;
-lastChange = "2023-09-12 04:44:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -16283,7 +16614,6 @@ unicode = 9496;
 },
 {
 glyphname = boxLightUpAndRight;
-lastChange = "2023-09-12 04:44:22 +0000";
 layers = (
 {
 layerId = m01;
@@ -16323,7 +16653,6 @@ unicode = 9492;
 },
 {
 glyphname = boxLightVertical;
-lastChange = "2023-09-12 04:33:00 +0000";
 layers = (
 {
 layerId = m01;
@@ -16345,7 +16674,6 @@ unicode = 9474;
 },
 {
 glyphname = boxLightVerticalAndHorizontal;
-lastChange = "2023-09-12 04:52:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -16376,7 +16704,6 @@ unicode = 9532;
 },
 {
 glyphname = boxLightVerticalAndLeft;
-lastChange = "2023-09-12 04:47:05 +0000";
 layers = (
 {
 layerId = m01;
@@ -16407,7 +16734,6 @@ unicode = 9508;
 },
 {
 glyphname = boxLightVerticalAndRight;
-lastChange = "2023-09-12 04:44:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -16438,7 +16764,6 @@ unicode = 9500;
 },
 {
 glyphname = boxRightDownHeavyAndLeftUpLight;
-lastChange = "2023-09-12 05:30:54 +0000";
 layers = (
 {
 layerId = m01;
@@ -16487,7 +16812,6 @@ unicode = 9542;
 },
 {
 glyphname = boxRightHeavyAndLeftDownLight;
-lastChange = "2023-09-12 04:47:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -16527,7 +16851,6 @@ unicode = 9518;
 },
 {
 glyphname = boxRightHeavyAndLeftUpLight;
-lastChange = "2023-09-12 04:52:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -16567,7 +16890,6 @@ unicode = 9526;
 },
 {
 glyphname = boxRightHeavyAndLeftVerticalLight;
-lastChange = "2023-09-12 04:52:26 +0000";
 layers = (
 {
 layerId = m01;
@@ -16607,7 +16929,6 @@ unicode = 9534;
 },
 {
 glyphname = boxRightLightAndLeftDownHeavy;
-lastChange = "2023-09-12 04:52:34 +0000";
 layers = (
 {
 layerId = m01;
@@ -16647,7 +16968,6 @@ unicode = 9521;
 },
 {
 glyphname = boxRightLightAndLeftUpHeavy;
-lastChange = "2023-09-12 04:52:43 +0000";
 layers = (
 {
 layerId = m01;
@@ -16687,7 +17007,6 @@ unicode = 9529;
 },
 {
 glyphname = boxRightLightAndLeftVerticalHeavy;
-lastChange = "2023-09-12 05:31:07 +0000";
 layers = (
 {
 layerId = m01;
@@ -16727,7 +17046,6 @@ unicode = 9545;
 },
 {
 glyphname = boxRightUpHeavyAndLeftDownLight;
-lastChange = "2023-09-12 05:31:18 +0000";
 layers = (
 {
 layerId = m01;
@@ -16776,7 +17094,6 @@ unicode = 9540;
 },
 {
 glyphname = boxUpDoubleAndHorizontalSingle;
-lastChange = "2023-09-13 03:18:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -16816,7 +17133,6 @@ unicode = 9576;
 },
 {
 glyphname = boxUpDoubleAndLeftSingle;
-lastChange = "2023-09-13 02:00:28 +0000";
 layers = (
 {
 layerId = m01;
@@ -16856,7 +17172,6 @@ unicode = 9564;
 },
 {
 glyphname = boxUpDoubleAndRightSingle;
-lastChange = "2023-09-13 02:00:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -16896,7 +17211,6 @@ unicode = 9561;
 },
 {
 glyphname = boxUpHeavyAndDownHorizontalLight;
-lastChange = "2023-09-12 05:31:30 +0000";
 layers = (
 {
 layerId = m01;
@@ -16936,7 +17250,6 @@ unicode = 9536;
 },
 {
 glyphname = boxUpHeavyAndHorizontalLight;
-lastChange = "2023-09-12 04:52:51 +0000";
 layers = (
 {
 layerId = m01;
@@ -16967,7 +17280,6 @@ unicode = 9528;
 },
 {
 glyphname = boxUpHeavyAndLeftDownLight;
-lastChange = "2023-09-12 04:47:24 +0000";
 layers = (
 {
 layerId = m01;
@@ -17016,7 +17328,6 @@ unicode = 9510;
 },
 {
 glyphname = boxUpHeavyAndLeftLight;
-lastChange = "2023-09-12 04:44:39 +0000";
 layers = (
 {
 layerId = m01;
@@ -17047,7 +17358,6 @@ unicode = 9498;
 },
 {
 glyphname = boxUpHeavyAndRightDownLight;
-lastChange = "2023-09-12 04:44:48 +0000";
 layers = (
 {
 layerId = m01;
@@ -17087,7 +17397,6 @@ unicode = 9502;
 },
 {
 glyphname = boxUpHeavyAndRightLight;
-lastChange = "2023-09-12 04:44:55 +0000";
 layers = (
 {
 layerId = m01;
@@ -17118,7 +17427,6 @@ unicode = 9494;
 },
 {
 glyphname = boxUpLightAndDownHorizontalHeavy;
-lastChange = "2023-09-12 05:31:44 +0000";
 layers = (
 {
 layerId = m01;
@@ -17158,7 +17466,6 @@ unicode = 9544;
 },
 {
 glyphname = boxUpLightAndHorizontalHeavy;
-lastChange = "2023-09-12 04:53:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -17189,7 +17496,6 @@ unicode = 9527;
 },
 {
 glyphname = boxUpLightAndLeftDownHeavy;
-lastChange = "2023-09-12 04:47:37 +0000";
 layers = (
 {
 layerId = m01;
@@ -17229,7 +17535,6 @@ unicode = 9514;
 },
 {
 glyphname = boxUpLightAndLeftHeavy;
-lastChange = "2023-09-12 04:45:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -17269,7 +17574,6 @@ unicode = 9497;
 },
 {
 glyphname = boxUpLightAndRightDownHeavy;
-lastChange = "2023-09-12 04:47:48 +0000";
 layers = (
 {
 layerId = m01;
@@ -17309,7 +17613,6 @@ unicode = 9506;
 },
 {
 glyphname = boxUpLightAndRightHeavy;
-lastChange = "2023-09-12 04:45:08 +0000";
 layers = (
 {
 layerId = m01;
@@ -17349,7 +17652,6 @@ unicode = 9493;
 },
 {
 glyphname = boxUpSingleAndHorizontalDouble;
-lastChange = "2023-09-13 03:19:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -17389,7 +17691,6 @@ unicode = 9575;
 },
 {
 glyphname = boxUpSingleAndLeftDouble;
-lastChange = "2023-09-13 02:01:29 +0000";
 layers = (
 {
 layerId = m01;
@@ -17429,7 +17730,6 @@ unicode = 9563;
 },
 {
 glyphname = boxUpSingleAndRightDouble;
-lastChange = "2023-09-13 02:01:42 +0000";
 layers = (
 {
 layerId = m01;
@@ -17469,7 +17769,6 @@ unicode = 9560;
 },
 {
 glyphname = boxVerticalDoubleAndHorizontalSingle;
-lastChange = "2023-09-13 03:19:31 +0000";
 layers = (
 {
 layerId = m01;
@@ -17509,7 +17808,6 @@ unicode = 9579;
 },
 {
 glyphname = boxVerticalDoubleAndLeftSingle;
-lastChange = "2023-09-13 03:19:40 +0000";
 layers = (
 {
 layerId = m01;
@@ -17549,7 +17847,6 @@ unicode = 9570;
 },
 {
 glyphname = boxVerticalDoubleAndRightSingle;
-lastChange = "2023-09-13 02:03:47 +0000";
 layers = (
 {
 layerId = m01;
@@ -17589,7 +17886,6 @@ unicode = 9567;
 },
 {
 glyphname = boxVerticalHeavyAndHorizontalLight;
-lastChange = "2023-09-12 05:31:58 +0000";
 layers = (
 {
 layerId = m01;
@@ -17620,7 +17916,6 @@ unicode = 9538;
 },
 {
 glyphname = boxVerticalHeavyAndLeftLight;
-lastChange = "2023-09-12 04:47:57 +0000";
 layers = (
 {
 layerId = m01;
@@ -17651,7 +17946,6 @@ unicode = 9512;
 },
 {
 glyphname = boxVerticalHeavyAndRightLight;
-lastChange = "2023-09-12 04:48:06 +0000";
 layers = (
 {
 layerId = m01;
@@ -17682,7 +17976,6 @@ unicode = 9504;
 },
 {
 glyphname = boxVerticalLightAndHorizontalHeavy;
-lastChange = "2023-09-12 04:53:15 +0000";
 layers = (
 {
 layerId = m01;
@@ -17713,7 +18006,6 @@ unicode = 9535;
 },
 {
 glyphname = boxVerticalLightAndLeftHeavy;
-lastChange = "2023-09-12 04:48:14 +0000";
 layers = (
 {
 layerId = m01;
@@ -17753,7 +18045,6 @@ unicode = 9509;
 },
 {
 glyphname = boxVerticalLightAndRightHeavy;
-lastChange = "2023-09-12 04:45:17 +0000";
 layers = (
 {
 layerId = m01;
@@ -17784,7 +18075,6 @@ unicode = 9501;
 },
 {
 glyphname = boxVerticalSingleAndHorizontalDouble;
-lastChange = "2023-09-13 03:20:03 +0000";
 layers = (
 {
 layerId = m01;
@@ -17824,7 +18114,6 @@ unicode = 9578;
 },
 {
 glyphname = boxVerticalSingleAndLeftDouble;
-lastChange = "2023-09-13 03:20:16 +0000";
 layers = (
 {
 layerId = m01;
@@ -17864,7 +18153,6 @@ unicode = 9569;
 },
 {
 glyphname = boxVerticalSingleAndRightDouble;
-lastChange = "2023-09-13 02:04:12 +0000";
 layers = (
 {
 layerId = m01;
@@ -17904,7 +18192,6 @@ unicode = 9566;
 },
 {
 glyphname = boxLeftDownHeavyAndRightUpLight.001;
-lastChange = "2023-09-12 05:32:09 +0000";
 layers = (
 {
 layerId = m01;
@@ -17952,11 +18239,19 @@ width = 620;
 unicode = 9541;
 },
 {
-export = 0;
 glyphname = dieresiscomb;
-lastChange = "2023-11-05 07:46:11 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (310,550);
+},
+{
+name = top;
+pos = (310,760);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -17984,11 +18279,58 @@ width = 620;
 unicode = 776;
 },
 {
-export = 0;
-glyphname = gravecomb;
-lastChange = "2023-11-06 02:48:29 +0000";
+glyphname = dotaccentcomb;
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (305,550);
+},
+{
+name = top;
+pos = (305,766);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(350,606,o),
+(385,641,o),
+(385,686,cs),
+(385,730,o),
+(350,766,o),
+(305,766,cs),
+(262,766,o),
+(225,730,o),
+(225,686,cs),
+(225,641,o),
+(262,606,o),
+(305,606,cs)
+);
+}
+);
+width = 620;
+}
+);
+unicode = 775;
+},
+{
+glyphname = gravecomb;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (291,550);
+},
+{
+name = top;
+pos = (291,786);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18008,11 +18350,19 @@ width = 620;
 unicode = 768;
 },
 {
-export = 0;
 glyphname = acutecomb;
-lastChange = "2023-11-05 07:40:35 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (336,550);
+},
+{
+name = top;
+pos = (336,786);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18032,11 +18382,19 @@ width = 620;
 unicode = 769;
 },
 {
-export = 0;
 glyphname = circumflexcomb;
-lastChange = "2023-11-05 07:40:38 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (304,550);
+},
+{
+name = top;
+pos = (304,786);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18066,11 +18424,61 @@ width = 620;
 unicode = 770;
 },
 {
-export = 0;
-glyphname = ringcomb;
-lastChange = "2023-11-05 07:40:55 +0000";
+glyphname = caroncomb;
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (304,550);
+},
+{
+name = top;
+pos = (304,786);
+}
+);
+layerId = m01;
+shapes = (
+{
+closed = 1;
+nodes = (
+(351,628,l),
+(351,634,l),
+(220,786,l),
+(135,786,l),
+(257,628,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(473,786,l),
+(388,786,l),
+(257,634,l),
+(257,628,l),
+(351,628,l)
+);
+}
+);
+width = 620;
+}
+);
+unicode = 780;
+},
+{
+glyphname = ringcomb;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (310,550);
+},
+{
+name = top;
+pos = (310,815);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18114,11 +18522,19 @@ width = 620;
 unicode = 778;
 },
 {
-export = 0;
 glyphname = tildecomb;
-lastChange = "2023-11-05 07:44:04 +0000";
 layers = (
 {
+anchors = (
+{
+name = _top;
+pos = (300,550);
+},
+{
+name = top;
+pos = (300,776);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18201,11 +18617,19 @@ width = 620;
 unicode = 771;
 },
 {
-export = 0;
 glyphname = cedillacomb;
-lastChange = "2023-11-05 11:07:16 +0000";
 layers = (
 {
+anchors = (
+{
+name = _bottom;
+pos = (325,0);
+},
+{
+name = bottom;
+pos = (325,-238);
+}
+);
 layerId = m01;
 shapes = (
 {
@@ -18396,8 +18820,438 @@ width = 620;
 unicode = 807;
 },
 {
+glyphname = dieresiscomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (310,710);
+},
+{
+name = top;
+pos = (310,908);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = dieresiscomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = dotaccentcomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (305,710);
+},
+{
+name = top;
+pos = (305,914);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = dotaccentcomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = gravecomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (291,710);
+},
+{
+name = top;
+pos = (291,934);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = gravecomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = acutecomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (336,710);
+},
+{
+name = top;
+pos = (336,934);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = acutecomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = circumflexcomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (304,710);
+},
+{
+name = top;
+pos = (304,934);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = circumflexcomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = caroncomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (304,710);
+},
+{
+name = top;
+pos = (304,934);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = caroncomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = ringcomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (310,710);
+},
+{
+name = top;
+pos = (310,963);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = ringcomb;
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = tildecomb.case;
+layers = (
+{
+anchors = (
+{
+name = _top;
+pos = (300,710);
+},
+{
+name = top;
+pos = (300,924);
+}
+);
+layerId = m01;
+shapes = (
+{
+pos = (0,148);
+ref = tildecomb;
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "1BBDF00C-EB6C-4E64-B2C8-BDE32526FA7D";
+name = "Oct 31, 23 at 16:47";
+shapes = (
+{
+closed = 1;
+nodes = (
+(362,593,o),
+(387,585,o),
+(483,705,c),
+(442,738,l),
+(374,658,o),
+(372,655,o),
+(317,705,cs),
+(238,776,o),
+(212,784,o),
+(117,664,c),
+(158,631,l),
+(226,711,o),
+(228,714,o),
+(283,664,cs)
+);
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "DD4C2753-9BA7-4192-9FB2-77BBBCFD02D8";
+name = "Nov 1, 23 at 15:47";
+shapes = (
+{
+closed = 1;
+nodes = (
+(467,573,o),
+(505,562,o),
+(646,738,c),
+(586,787,l),
+(486,669,o),
+(482,664,o),
+(401,739,cs),
+(285,844,o),
+(247,855,o),
+(106,679,c),
+(166,630,l),
+(266,748,o),
+(270,753,o),
+(351,678,cs)
+);
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = cedillacomb.case;
+layers = (
+{
+anchors = (
+{
+name = _bottom;
+pos = (325,0);
+},
+{
+name = bottom;
+pos = (325,-238);
+}
+);
+layerId = m01;
+shapes = (
+{
+ref = cedillacomb;
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "C1319835-1BEC-40EC-8000-5C6A6127892E";
+name = "Nov 2, 23 at 15:54";
+shapes = (
+{
+closed = 1;
+nodes = (
+(289,-96,l),
+(334,-96,o),
+(374,-102,o),
+(374,-126,cs),
+(374,-151,o),
+(342,-158,o),
+(307,-158,cs),
+(270,-158,o),
+(236,-143,o),
+(211,-129,c),
+(183,-180,l),
+(215,-201,o),
+(261,-216,o),
+(307,-216,cs),
+(383,-216,o),
+(436,-183,o),
+(436,-124,cs),
+(436,-87,o),
+(400,-46,o),
+(317,-46,c),
+(268,-45,l),
+(268,-96,l)
+);
+},
+{
+closed = 1;
+nodes = (
+(309,51,l),
+(228,-90,l),
+(228,-96,l),
+(289,-96,l),
+(382,51,l)
+);
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "04E3E119-9486-4EE1-A817-4CBB4D2E612A";
+name = "Nov 2, 23 at 16:04";
+shapes = (
+{
+closed = 1;
+nodes = (
+(229,-98,l),
+(314,-84,o),
+(378,-98,o),
+(377,-125,cs),
+(376,-149,o),
+(349,-158,o),
+(307,-158,cs),
+(270,-158,o),
+(236,-143,o),
+(211,-129,c),
+(183,-180,l),
+(215,-201,o),
+(261,-216,o),
+(307,-216,cs),
+(378,-216,o),
+(441,-195,o),
+(441,-126,cs),
+(441,-74,o),
+(393,-48,o),
+(327,-44,c),
+(382,51,l),
+(309,51,l),
+(229,-92,l)
+);
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "F850E069-D7E3-4896-BA2B-E21FB873FE83";
+name = "Nov 5, 23 at 16:48";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-90,o),
+(371,-102,o),
+(370,-134,cs),
+(369,-165,o),
+(332,-183,o),
+(296,-183,cs),
+(265,-183,o),
+(241,-175,o),
+(203,-154,c),
+(178,-205,l),
+(210,-226,o),
+(254,-241,o),
+(300,-241,cs),
+(369,-241,o),
+(434,-202,o),
+(436,-133,cs),
+(437,-90,o),
+(404,-39,o),
+(316,-51,c),
+(369,51,l),
+(302,51,l),
+(242,-77,l),
+(265,-110,l)
+);
+}
+);
+width = 620;
+},
+{
+associatedMasterId = m01;
+layerId = "09E9260D-AE90-4EEC-9A2F-673609A5CE43";
+name = "Nov 5, 23 at 16:56";
+shapes = (
+{
+closed = 1;
+nodes = (
+(333,-90,o),
+(371,-102,o),
+(370,-134,cs),
+(369,-165,o),
+(332,-183,o),
+(296,-183,cs),
+(265,-183,o),
+(241,-175,o),
+(203,-154,c),
+(178,-205,l),
+(210,-226,o),
+(254,-241,o),
+(300,-241,cs),
+(369,-241,o),
+(434,-202,o),
+(436,-133,cs),
+(437,-90,o),
+(404,-39,o),
+(316,-51,c),
+(369,51,l),
+(302,51,l),
+(242,-77,l),
+(265,-110,l)
+);
+}
+);
+width = 620;
+}
+);
+},
+{
 glyphname = grave;
-lastChange = "2023-11-06 03:33:13 +0000";
 layers = (
 {
 layerId = m01;
@@ -18442,14 +19296,6 @@ type = "x-height";
 );
 properties = (
 {
-key = postscriptFontName;
-value = "0xProto";
-},
-{
-key = manufacturerURL;
-value = "https://0xtype.dev/";
-},
-{
 key = copyrights;
 values = (
 {
@@ -18457,6 +19303,14 @@ language = dflt;
 value = "0xType Project Authors (https://github.com/0xType)";
 }
 );
+},
+{
+key = manufacturerURL;
+value = "https://0xtype.dev/";
+},
+{
+key = postscriptFontName;
+value = "0xProto";
 },
 {
 key = vendorID;
@@ -18469,6 +19323,7 @@ GSDimensionPlugin.Dimensions = {
 m01 = {
 };
 };
+GSDontShowVersionAlert = 1;
 };
 versionMajor = 1;
 versionMinor = 400;


### PR DESCRIPTION
You should use anchors which you can add with Cmd+U or Cmd+Shift+U in Glyphsapp.
They will be used when adding composite glyphs, and can be used to adjust already existing composite glyphs. The anchors are also exported as OpenType GPOS mark positioning, so combining marks can be used with base letters.

Add and use anchors.

Add .case variants of combining diacritics, shifted up.

Replace components in composite glyphs.

Add missing Zcaron.

Add and disable Write Last Change custom parameter.

Add ccmp feature.

Add and use dotaccentcomb, add dotaccentcomb.case.

Add and use caroncomb, caroncomb.case.

Export combining marks.