### PR TITLE
Set the width of `nbspace` to the same as the others

### DIFF
--- a/0xProto-Regular.ufo/glyphs/nbspace.glif
+++ b/0xProto-Regular.ufo/glyphs/nbspace.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="nbspace" format="2">
-  <advance width="600"/>
+  <advance width="620"/>
   <unicode hex="00A0"/>
   <outline>
   </outline>

--- a/0xProto.glyphs
+++ b/0xProto.glyphs
@@ -16954,7 +16954,7 @@ glyphname = nbspace;
 layers = (
 {
 layerId = m01;
-width = 600;
+width = 620;
 }
 );
 unicode = 160;


### PR DESCRIPTION
## What

TSIA

for https://github.com/0xType/0xProto/issues/59

Even though `isFixedPitch` is ON, oddly enough, the nbspace width got set to 600 for some reason 🤔 

## How it looks now

<img width="701" alt="image" src="https://github.com/0xType/0xProto/assets/1401513/23ae97eb-5aad-4be9-bfea-bb61cab27975">
