### PR TITLE
Ignore unexpected ligatures

### DIFF
--- a/sources/0xProto-Italic.glyphs
+++ b/sources/0xProto-Italic.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3303";
+.appVersion = "3306";
 .formatVersion = 3;
 classes = (
 {
@@ -299,6 +299,8 @@ lookup less_bar {
 
 # ||
 lookup bar_bar {
+  ignore sub bar' bar bar;
+  ignore sub bar bar' bar;
   sub bar.spacer bar' by bar_bar;
   sub bar' bar by bar.spacer;
 } bar_bar;
@@ -527,12 +529,16 @@ lookup numbersign_equal {
 
 # %%
 lookup percent_percent {
+  ignore sub percent' percent percent;
+  ignore sub percent percent' percent;
   sub percent.spacer percent' by percent_percent;
   sub percent' percent by percent.spacer;
 } percent_percent;
 
 # &&
 lookup ampersand_ampersand {
+  ignore sub ampersand' ampersand ampersand;
+  ignore sub ampersand ampersand' ampersand;
   sub ampersand.spacer ampersand' by ampersand_ampersand;
   sub ampersand' ampersand by ampersand.spacer;
 } ampersand_ampersand;

--- a/sources/0xProto-Italic.ufo/features.fea
+++ b/sources/0xProto-Italic.ufo/features.fea
@@ -260,6 +260,8 @@ lookup less_bar {
 
 # ||
 lookup bar_bar {
+  ignore sub bar' bar bar;
+  ignore sub bar bar' bar;
   sub bar.spacer bar' by bar_bar;
   sub bar' bar by bar.spacer;
 } bar_bar;
@@ -488,12 +490,16 @@ lookup numbersign_equal {
 
 # %%
 lookup percent_percent {
+  ignore sub percent' percent percent;
+  ignore sub percent percent' percent;
   sub percent.spacer percent' by percent_percent;
   sub percent' percent by percent.spacer;
 } percent_percent;
 
 # &&
 lookup ampersand_ampersand {
+  ignore sub ampersand' ampersand ampersand;
+  ignore sub ampersand ampersand' ampersand;
   sub ampersand.spacer ampersand' by ampersand_ampersand;
   sub ampersand' ampersand by ampersand.spacer;
 } ampersand_ampersand;

--- a/sources/0xProto-Italic.ufo/lib.plist
+++ b/sources/0xProto-Italic.ufo/lib.plist
@@ -37,7 +37,7 @@
       </dict>
     </array>
     <key>com.schriftgestaltung.appVersion</key>
-    <string>3303</string>
+    <string>3306</string>
     <key>com.schriftgestaltung.customParameter.GSFont.Write lastChange</key>
     <integer>0</integer>
     <key>com.schriftgestaltung.customParameter.GSFont.disablesAutomaticAlignment</key>

--- a/sources/0xProto-Regular.ufo/features.fea
+++ b/sources/0xProto-Regular.ufo/features.fea
@@ -260,6 +260,8 @@ lookup less_bar {
 
 # ||
 lookup bar_bar {
+  ignore sub bar' bar bar;
+  ignore sub bar bar' bar;
   sub bar.spacer bar' by bar_bar;
   sub bar' bar by bar.spacer;
 } bar_bar;
@@ -488,12 +490,16 @@ lookup numbersign_equal {
 
 # %%
 lookup percent_percent {
+  ignore sub percent' percent percent;
+  ignore sub percent percent' percent;
   sub percent.spacer percent' by percent_percent;
   sub percent' percent by percent.spacer;
 } percent_percent;
 
 # &&
 lookup ampersand_ampersand {
+  ignore sub ampersand' ampersand ampersand;
+  ignore sub ampersand ampersand' ampersand;
   sub ampersand.spacer ampersand' by ampersand_ampersand;
   sub ampersand' ampersand by ampersand.spacer;
 } ampersand_ampersand;

--- a/sources/0xProto-Regular.ufo/lib.plist
+++ b/sources/0xProto-Regular.ufo/lib.plist
@@ -37,7 +37,7 @@
       </dict>
     </array>
     <key>com.schriftgestaltung.appVersion</key>
-    <string>3303</string>
+    <string>3306</string>
     <key>com.schriftgestaltung.customParameter.GSFont.Write lastChange</key>
     <integer>0</integer>
     <key>com.schriftgestaltung.customParameter.GSFont.disablesAutomaticAlignment</key>

--- a/sources/0xProto.glyphs
+++ b/sources/0xProto.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3303";
+.appVersion = "3306";
 .formatVersion = 3;
 classes = (
 {
@@ -299,6 +299,8 @@ lookup less_bar {
 
 # ||
 lookup bar_bar {
+  ignore sub bar' bar bar;
+  ignore sub bar bar' bar;
   sub bar.spacer bar' by bar_bar;
   sub bar' bar by bar.spacer;
 } bar_bar;
@@ -527,12 +529,16 @@ lookup numbersign_equal {
 
 # %%
 lookup percent_percent {
+  ignore sub percent' percent percent;
+  ignore sub percent percent' percent;
   sub percent.spacer percent' by percent_percent;
   sub percent' percent by percent.spacer;
 } percent_percent;
 
 # &&
 lookup ampersand_ampersand {
+  ignore sub ampersand' ampersand ampersand;
+  ignore sub ampersand ampersand' ampersand;
   sub ampersand.spacer ampersand' by ampersand_ampersand;
   sub ampersand' ampersand by ampersand.spacer;
 } ampersand_ampersand;


### PR DESCRIPTION
## What

unlocked ligatures that are unexpected when three or more of a particular character is in a row

for https://github.com/0xType/0xProto/issues/73

### Before

<img width="566" alt="image" src="https://github.com/0xType/0xProto/assets/1401513/9858614a-bc54-4151-be86-3c5d1e099e36">

### After

<img width="569" alt="image" src="https://github.com/0xType/0xProto/assets/1401513/41552417-d9c5-44f9-895b-2451c7ce8140">
